### PR TITLE
CI: bump actions/upload-artifact v4 -> v7 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: make coverage
       - name: Upload coverage report
         if: always()   # publish the report even if a prior step failed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |


### PR DESCRIPTION
## What

Bump `actions/upload-artifact@v4` → `@v7` in `.github/workflows/ci.yml` (coverage job).

## Why

GitHub-hosted runners [removed the Node 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so v4 was being force-run on Node 24 and emitting:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/upload-artifact@v4.
```

It was also the source of the `punycode` / `url.parse()` DEP notices in that step (v4's Node 20 code on a runtime it wasn't shipped for). `actions/checkout` was already on v5/Node 24; upload-artifact was the only lagging action.

## Safety

v7 ships native Node 24 support. None of the v5→v7 changes affect this workflow's usage (named, zipped, multi-file glob upload). v7's only new behavior is the opt-in `archive: false` single-file mode, which defaults off. v6+ requires runner ≥ 2.327.1, always satisfied on GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)