### PR TITLE
Analyzer: move Swordfish after Simple Coloring and Y-Wing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ echo -e "v\nn.board_string\n.\n.\n.\n.\n.\n.\n.\n.\n.\n." | ./sudoku-solver | gr
 - [LC] = Locked Candidates
 - [HP] = Hidden Pairs
 - [XW] = XWing patterns
+- [SC] = Simple Coloring (single's chains)
+- [YW] = Y-Wing
+- [SF] = Swordfish
+- [XY] = XY-Chain
 
 ## Reading board display output
 The visual board display shows each Sudoku cell as a 3x3 grid of positions representing candidate values:

--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ Notes remaining: 210
 [XW](0) {}
 [SC](0) {}
 [YW](0) {}
+[SF](0) {}
 [XY](0) {}
 ```
 
-There are currently nine implemented heuristics: 
+There are currently ten implemented heuristics: 
 
 1. `naked-single`, denoted as `[NS]`,
 1. `hidden-single`, denoted as `[HS]`,
@@ -189,7 +190,8 @@ There are currently nine implemented heuristics:
 1. `hidden-pairs`, denoted as `[HP]`,
 1. `x-wing`, denoted as `[XW]`,
 1. `simple-coloring`, denoted as `[SC]`,
-1. `y-wing`, denoted as `[YW]`, and
+1. `y-wing`, denoted as `[YW]`,
+1. `swordfish`, denoted as `[SF]`, and
 1. `XY-chain`, denoted as `[XY]`.
 
 For each heuristic, the number of available actions associated with the heuristic appears in parentheses, followed by a summary description of such actions.
@@ -430,6 +432,7 @@ Notes remaining: 47
 [XW](0) {}
 [SC](1) {{{[4, 8]🟩,[9, 8]🟥,[8, 7]🟩,[6, 5]🟩,[6, 7]🟥,[9, 5]🟥}#5}}
 [YW](0) {}
+[SF](0) {}
 [XY](0) {}
 ```
 However, `[9, 5]` is colored red, but sees `[9, 8]` also colored red. Per "Rule 2", all reds from the chain can be eliminated:
@@ -448,13 +451,17 @@ Additionally, "Rule 4" also applies, with `[8, 4]` and `[8, 6]` seeing both red 
 
 TODO
 
+## Swordfish
+
+TODO
+
 ## XY-Chain
 
 TODO
 
 ## Order of analysis and resolution
 
-The solver will stop analysis when a heuristic detects possible actions. The order of evaluation of heuristics is as in the ordered list above. When solving for a given heuristic, in a given step, the solver will execute on *all* possible actions for Naked Singles, Hidden Singles, Haked Pairs, Locked Candidates, Hidden Pairs and Y-Wing, and on only the first possible action for X-Wing, Simple Coloring and XY-Chain.
+The solver will stop analysis when a heuristic detects possible actions. The order of evaluation of heuristics is as in the ordered list above. When solving for a given heuristic, in a given step, the solver will execute on *all* possible actions for Naked Singles, Hidden Singles, Haked Pairs, Locked Candidates, Hidden Pairs and Y-Wing, and on only the first possible action for X-Wing, Simple Coloring, Swordfish and XY-Chain.
 
 # Editing the table
 

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -71,9 +71,9 @@ void Analyzer::analyze() {
     if (!did_find) did_find = find_locked_candidates();
     if (!did_find) did_find = find_hidden_pairs();
     if (!did_find) did_find = find_xwings();
-    if (!did_find) did_find = find_swordfish();
     if (!did_find) did_find = find_color_chains();
     if (!did_find) did_find = find_ywings();
+    if (!did_find) did_find = find_swordfish();
     if (!did_find) did_find = find_xychains();
 }
 
@@ -88,9 +88,9 @@ bool Analyzer::act(const bool singles_only) {
         if (!did_act) did_act = act_on_locked_candidate();
         if (!did_act) did_act = act_on_hidden_pair();
         if (!did_act) did_act = act_on_xwing();
-        if (!did_act) did_act = act_on_swordfish();
         if (!did_act) did_act = act_on_color_chain();
         if (!did_act) did_act = act_on_ywing();
+        if (!did_act) did_act = act_on_swordfish();
         if (!did_act) did_act = act_on_xychain();
     }
 
@@ -123,9 +123,9 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     print_section(outs, "LC", a.mLockedCandidates, true);  outs << std::endl;
     print_section(outs, "HP", a.mHiddenPairs,      true);  outs << std::endl;
     print_section(outs, "XW", a.mXWings,           true);  outs << std::endl;
-    print_section(outs, "SF", a.mSwordfish,        true);  outs << std::endl;
     print_section(outs, "SC", a.mColorChains,      true);  outs << std::endl; // a.k.a. single's chains
     print_section(outs, "YW", a.mYWings,           true);  outs << std::endl;
+    print_section(outs, "SF", a.mSwordfish,        true);  outs << std::endl;
     print_section(outs, "XY", a.mXYChains,         true);
 
     return outs;


### PR DESCRIPTION
## Summary

Reorders the heuristic evaluation so **Swordfish** runs in position 9 (after X-Wing → Simple Coloring → Y-Wing, before XY-Chain) rather than position 7.

This better matches a human solving progression: a three-line fish is harder to spot and rarer than a local Y-Wing or a simple-coloring chain, so a person reaches for those first. Previously Swordfish was grouped with X-Wing by code family (both are "fish"), which is a code-organization grouping rather than a difficulty one.

The reorder does **not** affect correctness or whether a board solves: every technique only places forced values or eliminates genuinely-impossible candidates, so any order converges to the same solution. The payoff is purely that the solve trace reads more like a human did it.

## Changes

- **`analyzer.cpp`** — Swordfish moved in the three places that must stay in lockstep: `analyze()`, `act()`, and `operator<<` (the dump still mirrors evaluation order).
- **`README.md`** — backfilled stale docs: the list said "nine" and omitted Swordfish (now ten); added the missing `[SF]` line to both analyzer-dump examples; folded Swordfish into the "first possible action" group in the order paragraph; added a Swordfish section stub.
- **`CLAUDE.md`** — completed the pattern abbreviation list (`SC`/`YW`/`SF`/`XY` were missing) in the new evaluation order.

## Testing

- `make` builds clean.
- Full blackbox suite: **80 passed, 0 failed**, including the two fixtures that put Swordfish on the critical path (`P_hard` partial-solve, `P_sf` full-solve) and the per-technique SF precision check. They still fire Swordfish after the reorder, confirming no Simple Coloring or Y-Wing elimination preempts it on those boards.
- Whitebox unit tests: all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)