### PR TITLE
Notes: uint16_t bitmask; Cell value as optional<Value> (#10, #12.1/.3)

### DIFF
--- a/analyzer-colorchain.cpp
+++ b/analyzer-colorchain.cpp
@@ -179,7 +179,7 @@ bool Analyzer::find_color_chains() {
     //          chain can see two colors on the chain, then it can be eliminated.
     bool did_find = false;
 
-    for (Value val : value_range(kOne, kUnset)) {
+    for (Value val : value_range()) {
         did_find = find_color_chains(val);
         if (!did_find) continue;
         break;

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -43,7 +43,7 @@ namespace { // anon
     }
 }
 
-bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, Value &out_value) const {
+bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value) const {
     // by construct, all these assertions apply for input parameters
     assert(pivot != wing1);
     assert(pivot != wing2);
@@ -90,7 +90,7 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
 
     out_value = wing1_other;
 
-    if (!would_act(mBoard, pivot, wing1, wing2, out_value)) return false;
+    if (!would_act(mBoard, pivot, wing1, wing2, wing1_other)) return false;
 
     return true;
 }
@@ -141,13 +141,14 @@ bool Analyzer::find_ywing(const Cell &pivot) {
             const Cell &wing1 = *it1;
             const Cell &wing2 = *it2;
 
-            Value ywing_value;  // set by test_ywing when it returns true
+            std::optional<Value> ywing_value;
             if (!test_ywing(pivot, wing1, wing2, ywing_value)) continue;
-            assert(wing1.check(ywing_value));
-            assert(wing2.check(ywing_value));
+            assert(ywing_value.has_value());
+            assert(wing1.check(*ywing_value));
+            assert(wing2.check(*ywing_value));
 
             // Record the Y-Wing pattern
-            YWing yw{ywing_value, pivot.coord(), {wing1.coord(), wing2.coord()}};
+            YWing yw{*ywing_value, pivot.coord(), {wing1.coord(), wing2.coord()}};
             if (std::find(mYWings.begin(), mYWings.end(), yw) != mYWings.end()) continue;
 
             mYWings.push_back(yw);

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -61,7 +61,7 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     assert(mBoard.see_each_other(pivot, wing2));
 
     // does wing1 share only one value with pivot (and which is it?)
-    Value wing1_shared = kUnset;
+    std::optional<Value> wing1_shared;
     if (pivot.check(wing1.notes().values()[0])) {
         if (pivot.check(wing1.notes().values()[1])) return false;
         wing1_shared = wing1.notes().values()[0];
@@ -71,7 +71,7 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     }
 
     // yes! but does wing2 share only one value with pivot (and which is it?)
-    Value wing2_shared = kUnset;
+    std::optional<Value> wing2_shared;
     if (pivot.check(wing2.notes().values()[0])) {
         if (pivot.check(wing2.notes().values()[1])) return false;
         wing2_shared = wing2.notes().values()[0];
@@ -141,7 +141,7 @@ bool Analyzer::find_ywing(const Cell &pivot) {
             const Cell &wing1 = *it1;
             const Cell &wing2 = *it2;
 
-            Value ywing_value = kUnset;
+            Value ywing_value;  // set by test_ywing when it returns true
             if (!test_ywing(pivot, wing1, wing2, ywing_value)) continue;
             assert(wing1.check(ywing_value));
             assert(wing2.check(ywing_value));

--- a/analyzer.h
+++ b/analyzer.h
@@ -247,7 +247,7 @@ private:
     std::vector<YWing> mYWings;
 
     // find
-    bool test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, Value &out_value) const;
+    bool test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value) const;
     bool find_ywing(const Cell &pivot);
     bool find_ywings();
 

--- a/board.cpp
+++ b/board.cpp
@@ -201,7 +201,7 @@ void Board::print_candidates(std::ostream &out) const {
                 out << c.value();
             } else {
                 bool any = false;
-                for (Value v : value_range(kOne, kUnset)) {
+                for (Value v : value_range()) {
                     if (c.check(v)) { out << static_cast<int>(v); any = true; }
                 }
                 if (!any) out << '-';

--- a/cell.cpp
+++ b/cell.cpp
@@ -7,38 +7,23 @@
 
 void Cell::set(const Value &v) {
     assert(isNote());
-    assert(v != kUnset);
 
     mNotes.clear();
     mValue = v;
 }
 
 bool Notes::set(const Value &v, bool set) {
-
-    bool note = mNotes.at(v - 1);
-    mNotes[v - 1] = set;
+    bool note = check(v);
+    if (set) mNotes |=  bit(v);
+    else     mNotes &= ~bit(v);
     return note;
-}
-
-size_t Notes::count() const {
-    size_t count = 0;
-    for (auto const &v : mNotes) {
-        if (v) count++;
-    }
-    return count;
 }
 
 std::vector<Value> Notes::values() const {
     std::vector<Value> v;
-    if (check(kOne))   v.push_back(kOne);
-    if (check(kTwo))   v.push_back(kTwo);
-    if (check(kThree)) v.push_back(kThree);
-    if (check(kFour))  v.push_back(kFour);
-    if (check(kFive))  v.push_back(kFive);
-    if (check(kSix))   v.push_back(kSix);
-    if (check(kSeven)) v.push_back(kSeven);
-    if (check(kEight)) v.push_back(kEight);
-    if (check(kNine))  v.push_back(kNine);
+    for (Value value : value_range()) {
+        if (check(value)) v.push_back(value);
+    }
     return v;
 }
 
@@ -57,7 +42,7 @@ void Cell::print_row(std::ostream &outs, size_t row) const {
     }
     else {
         // A solved cell shows its value centered on the middle line only.
-        if (row == 1) outs << "  " << mValue << "  ";
+        if (row == 1) outs << "  " << *mValue << "  ";
         else          outs << "     ";
     }
 }

--- a/cell.h
+++ b/cell.h
@@ -4,7 +4,11 @@
 
 #include <functional>
 #include <cassert>
+#include <bit>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <ranges>
 
@@ -19,46 +23,54 @@ enum Value: int {
     kSix,
     kSeven,
     kEight,
-    kNine,
-    kUnset
+    kNine
 };
 
-inline auto value_range(Value begin, Value end) {
-    return std::views::iota(static_cast<int>(begin), static_cast<int>(end))
+// Iterate the nine digit values kOne..kNine. The transform turns the integer
+// iota back into Value; iota's half-open [begin, end) is why the end is one
+// past kNine.
+inline auto value_range() {
+    return std::views::iota(static_cast<int>(kOne), static_cast<int>(kNine) + 1)
          | std::views::transform([](int i) { return static_cast<Value>(i); });
 }
 
 class Cell;
 
+// The nine candidate flags packed into a bitmask: bit (v - 1) is set when v is
+// still a candidate. A plain integer keeps Notes (and therefore Cell) trivially
+// copyable, with no per-cell heap allocation.
 class Notes {
 public:
     Notes()
-        : mNotes(kNine, true) { }
+        : mNotes(kAllCandidates) { }
 
-    void clear() { mNotes.clear(); }
+    void clear() { mNotes = 0; }
 
-    bool check(const Value &v) const { return mNotes.at(v - 1); }
+    bool check(const Value &v) const { return (mNotes & bit(v)) != 0; }
     bool set(const Value &v, bool set);
-    bool set_all(bool set) { mNotes.assign(mNotes.size(), set); return true; }
+    bool set_all(bool set) { mNotes = set ? kAllCandidates : 0; return true; }
 
-    size_t count() const;
+    size_t count() const { return std::popcount(mNotes); }
     std::vector<Value> values() const;
 
 private:
-    std::vector<bool> mNotes;
+    static constexpr uint16_t bit(const Value &v) { return static_cast<uint16_t>(1u << (v - 1)); }
+    static constexpr uint16_t kAllCandidates = 0x1ffu; // bits 0..8 -> values 1..9
+
+    uint16_t mNotes;
 };
 
 class Cell {
 public:
     Cell(size_t line, size_t column)
         : mCoord(line, column)
-        , mValue(kUnset) { }
+        , mValue(std::nullopt) { }
 
-    bool isNote() const { return mValue == kUnset; }
-    bool isValue() const { return !isNote(); }
+    bool isNote() const { return !mValue.has_value(); }
+    bool isValue() const { return mValue.has_value(); }
 
     const Coord &coord() const { return mCoord; }
-    Value value() const { return mValue; }
+    Value value() const { assert(isValue()); return *mValue; }
     Notes &notes() { assert(isNote()); return mNotes; }
     const Notes &notes() const { assert(isNote()); return mNotes; }
     Value other_value(const Value &value) const {
@@ -86,9 +98,20 @@ public:
 private:
     const Coord mCoord;
 
-    Value mValue;
+    std::optional<Value> mValue;
     Notes mNotes;
 };
+
+// Copies of Cell happen in the analyzer's inner loop (candidates()) and in the
+// per-solve-step SolverState copy; keeping copy construction trivial means those
+// copies are a plain memcpy with no heap traffic. We assert *copy construction*
+// rather than full is_trivially_copyable because the const mCoord intentionally
+// deletes copy assignment (Cell is copy-constructible but not assignable), and a
+// deleted assignment is enough to make is_trivially_copyable false.
+static_assert(std::is_trivially_copy_constructible_v<Cell>,
+              "Cell copies must stay a trivial memcpy (no per-cell heap allocation)");
+static_assert(std::is_trivially_destructible_v<Cell>,
+              "Cell must stay trivially destructible");
 
 template<>
 struct std::hash<Cell> {

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -286,12 +286,11 @@ void test_ywing_rejects_non_patterns() {
     set_candidates(board, 2, 0, {2, 5});   // shares 2, other 5 (!= 3)
 
     Analyzer analyzer(board);
-    Value out = kUnset;
+    Value out;  // out-param; only meaningful when test_ywing returns true
     bool both_share_one = AnalyzerTest::test_ywing(analyzer,
         cell_at(board, 0, 0), cell_at(board, 0, 1), cell_at(board, 1, 0), out);
     check(!both_share_one, "rejected: both wings share the same value with the pivot");
 
-    out = kUnset;
     bool others_differ = AnalyzerTest::test_ywing(analyzer,
         cell_at(board, 0, 0), cell_at(board, 0, 1), cell_at(board, 2, 0), out);
     check(!others_differ, "rejected: the wings' non-shared values differ");

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -72,7 +72,7 @@ struct AnalyzerTest {
 
     // --- y-wing ---
     static bool   find_ywing(Analyzer &a, const Cell &pivot)                                       { return a.find_ywing(pivot); }
-    static bool   test_ywing(const Analyzer &a, const Cell &p, const Cell &w1, const Cell &w2, Value &out) { return a.test_ywing(p, w1, w2, out); }
+    static bool   test_ywing(const Analyzer &a, const Cell &p, const Cell &w1, const Cell &w2, std::optional<Value> &out) { return a.test_ywing(p, w1, w2, out); }
     static bool   act_on_ywing(Analyzer &a)                                                        { return a.act_on_ywing(); }
     static size_t ywing_count(const Analyzer &a)                                                   { return a.mYWings.size(); }
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
@@ -286,7 +286,7 @@ void test_ywing_rejects_non_patterns() {
     set_candidates(board, 2, 0, {2, 5});   // shares 2, other 5 (!= 3)
 
     Analyzer analyzer(board);
-    Value out;  // out-param; only meaningful when test_ywing returns true
+    std::optional<Value> out;  // out-param; only engaged when test_ywing returns true
     bool both_share_one = AnalyzerTest::test_ywing(analyzer,
         cell_at(board, 0, 0), cell_at(board, 0, 1), cell_at(board, 1, 0), out);
     check(!both_share_one, "rejected: both wings share the same value with the pivot");


### PR DESCRIPTION
## What

Reworks `Notes` storage and `Cell`'s solved-state representation.

### #10a — `Notes` → `uint16_t` bitmask
`Notes` stored its nine candidate flags as a `std::vector<bool>` (`cell.h`), i.e. a heap allocation per cell, deep-copied on every `Cell` copy. Since `candidates()` copies whole `Cell`s in the inner loop of every technique, and `SolverState` (hence every `Cell`) is copied each solve step, that allocation churn sat on the hot path.

Now `Notes` is a `uint16_t` (bit `v-1` set ⇔ `v` is a candidate). `count()` is `std::popcount`; `check/set/set_all/clear/values` keep the same interface. This removes the **per-cell `Notes` allocation** and makes a `Cell` copy a trivial memcpy.

> **Scope note (thanks to review):** this removes the per-`Notes` allocation and the deep copy in `Cell` copies; it does **not** make the hot path allocation-free. `Notes::values()` still returns a freshly heap-allocated `std::vector<Value>` and is called heavily in the same inner loops (`select_wing_candidates`, `test_ywing`). That allocation is a separate, larger change tracked in #17.

Locked in with:
```cpp
static_assert(std::is_trivially_copy_constructible_v<Cell>, ...);
static_assert(std::is_trivially_destructible_v<Cell>, ...);
```
Note: **not** `is_trivially_copyable`. The intentional `const Coord mCoord` deletes copy *assignment*, and a deleted assignment is enough to make `is_trivially_copyable` false. Trivial copy *construction* is the property the analyzer inner loop and the per-step `SolverState` copy actually rely on, and it holds. (Matches the issue's own note: Cell is "copy-constructible but not assignable".)

### Folded-in cleanups from #12
- **#12.1**: `Notes::values()` iterates `value_range()` instead of nine hand-unrolled `check()` calls.
- **#12.3**: `kUnset` removed from the `Value` enum. A cell's solved state is `std::optional<Value>`, and `value_range()` is a no-arg range over the nine digits — so `kUnset` no longer doubles as both "no value" and the range sentinel. "No value yet" slots (the `wing*_shared` locals and the `test_ywing` out-param) are `std::optional<Value>`.

### Deferred: #10's part (b)
Issue #10 also recommended stopping `candidates()` from copying `Cell`s (return `const Cell*`/`Coord`). Deliberately **not** done: after the bitmask change the copy is a trivial memcpy, so it would only trade a cheap copy for deref noise (and a coord-equality → pointer-identity shift in the `std::find` checks). Worth revisiting only if a profiler flags `candidates()`.

## Testing
- Clean build under `-Wall -Werror`.
- `make unit` (whitebox): all checks pass.
- `make test` (integration): 80/80.

Closes #10. Addresses #12 items 1 and 3 (item 2, the `see_each_other` enum, is independent and left for #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)