### PR TITLE
Y-Wing: assert exactly-one-shared precondition in test_ywing (#18)

### DIFF
--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -60,25 +60,20 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     assert(mBoard.see_each_other(pivot, wing1));
     assert(mBoard.see_each_other(pivot, wing2));
 
-    // does wing1 share only one value with pivot (and which is it?)
-    std::optional<Value> wing1_shared;
-    if (pivot.check(wing1.notes().values()[0])) {
-        if (pivot.check(wing1.notes().values()[1])) return false;
-        wing1_shared = wing1.notes().values()[0];
-    } else {
-        if (pivot.check(wing1.notes().values()[0])) return false;
-        wing1_shared = wing1.notes().values()[1];
-    }
+    // by construct (select_wing_candidates), each wing shares exactly one value
+    // with the pivot: candidates with no value in common with the pivot are
+    // skipped (at least one shared), and candidates with the identical 2-value
+    // set as the pivot are skipped (no more than one shared).
 
-    // yes! but does wing2 share only one value with pivot (and which is it?)
-    std::optional<Value> wing2_shared;
-    if (pivot.check(wing2.notes().values()[0])) {
-        if (pivot.check(wing2.notes().values()[1])) return false;
-        wing2_shared = wing2.notes().values()[0];
-    } else {
-        if (pivot.check(wing2.notes().values()[0])) return false;
-        wing2_shared = wing2.notes().values()[1];
-    }
+    // which value does wing1 share with pivot?
+    const auto &w1 = wing1.notes().values();
+    assert(pivot.check(w1[0]) != pivot.check(w1[1]));
+    std::optional<Value> wing1_shared = pivot.check(w1[0]) ? w1[0] : w1[1];
+
+    // which value does wing2 share with pivot?
+    const auto &w2 = wing2.notes().values();
+    assert(pivot.check(w2[0]) != pivot.check(w2[1]));
+    std::optional<Value> wing2_shared = pivot.check(w2[0]) ? w2[0] : w2[1];
 
     // yes! but do wing1 and wing2 share different values with pivot?
     if (wing1_shared == wing2_shared) return false;

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -68,19 +68,19 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     // which value does wing1 share with pivot?
     const auto &w1 = wing1.notes().values();
     assert(pivot.check(w1[0]) != pivot.check(w1[1]));
-    std::optional<Value> wing1_shared = pivot.check(w1[0]) ? w1[0] : w1[1];
+    Value wing1_shared = pivot.check(w1[0]) ? w1[0] : w1[1];
 
     // which value does wing2 share with pivot?
     const auto &w2 = wing2.notes().values();
     assert(pivot.check(w2[0]) != pivot.check(w2[1]));
-    std::optional<Value> wing2_shared = pivot.check(w2[0]) ? w2[0] : w2[1];
+    Value wing2_shared = pivot.check(w2[0]) ? w2[0] : w2[1];
 
     // yes! but do wing1 and wing2 share different values with pivot?
     if (wing1_shared == wing2_shared) return false;
 
     // Find the elimination candidate (the candidate that both wings have but pivot doesn't)
-    Value wing1_other = wing1_shared == wing1.notes().values()[0] ? wing1.notes().values()[1] : wing1.notes().values()[0];
-    Value wing2_other = wing2_shared == wing2.notes().values()[0] ? wing2.notes().values()[1] : wing2.notes().values()[0];
+    Value wing1_other = wing1.other_value(wing1_shared);
+    Value wing2_other = wing2.other_value(wing2_shared);
     if (wing1_other != wing2_other) return false;
 
     out_value = wing1_other;

--- a/cell.h
+++ b/cell.h
@@ -53,6 +53,14 @@ public:
     size_t count() const { return std::popcount(mNotes); }
     std::vector<Value> values() const;
 
+    // For a two-candidate cell, the candidate that isn't v. Clearing v's bit
+    // leaves a single bit standing; its position (0-based) is the value minus 1.
+    Value other_value(const Value &v) const {
+        assert(count() == 2);
+        assert(check(v));
+        return static_cast<Value>(std::countr_zero<uint16_t>(mNotes & ~bit(v)) + 1);
+    }
+
 private:
     static constexpr uint16_t bit(const Value &v) { return static_cast<uint16_t>(1u << (v - 1)); }
     static constexpr uint16_t kAllCandidates = 0x1ffu; // bits 0..8 -> values 1..9
@@ -74,10 +82,7 @@ public:
     Notes &notes() { assert(isNote()); return mNotes; }
     const Notes &notes() const { assert(isNote()); return mNotes; }
     Value other_value(const Value &value) const {
-        assert(isNote());
-        assert(notes().count() == 2);
-        assert(check(value));
-        return notes().values()[0] == value ? notes().values()[1] : notes().values()[0];
+        return notes().other_value(value);
     }
 
     bool check(const Value &v) const { return isNote() && mNotes.check(v); }


### PR DESCRIPTION
## Summary

`test_ywing` determined which value each wing shared with the pivot using branchy guards that could only `return false` if `select_wing_candidates` were broken:

- The two **`else`-branch** guards were *literally* dead: they re-tested `pivot.check(v0)`, already known false on that path.
- The two **`if`-branch** guards were *invariant*-dead: they caught the "both shared" case that `select_wing_candidates` already excludes.

`select_wing_candidates` guarantees each wing shares **exactly one** value with the pivot — it skips candidates with no value in common with the pivot (at least one shared) and skips candidates whose 2-value set is identical to the pivot's (no more than one shared). That is a by-construct precondition, like the `count`/`isNote`/`see_each_other` asserts already at the top of `test_ywing`.

This replaces the four return-false guards with per-wing assertions of that precondition, matching the existing assert-the-contract style and removing the dead branches.

## Testing

- `make` — clean (`-Wall -Werror`)
- `make test` — 80/80 pass
- `make unit` — all checks pass, including the y-wing whitebox near-miss rejections (which hit the still-present `wing1_shared == wing2_shared` and non-shared-values-differ guards)

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)