### PR TITLE
Replace stringly-typed unit tags with enum class Unit across Board + Analyzer (#12.2)

### DIFF
--- a/analyzer-colorchain.cpp
+++ b/analyzer-colorchain.cpp
@@ -22,8 +22,7 @@ bool Analyzer::ColorChain::cell_sees_both_colors(const Cell &cell, const Board &
     bool did_see_red = false;
 
     for (const auto &[colored_coord, color] : cells) {
-        std::string tag;
-        if (board.see_each_other(cell.coord(), colored_coord, tag)) {
+        if (board.see_each_other(cell.coord(), colored_coord)) {
             if (color) { did_see_green = true; }
             else       { did_see_red = true; }
             if (did_see_green && did_see_red) break;
@@ -39,9 +38,8 @@ bool Analyzer::test_color_chain(const ColorChain &chain) const {
 
     // Check rule 2: cells of same color in the same unit
     auto [green_cells, red_cells] = chain.group_cells_by_color();
-    std::string tag;
-    if (mBoard.any_see_each_other(green_cells, tag)
-     || mBoard.any_see_each_other(red_cells, tag)) {
+    if (mBoard.any_see_each_other(green_cells)
+     || mBoard.any_see_each_other(red_cells)) {
         return true;
     }
 
@@ -194,10 +192,9 @@ bool act_on_color_chain_rule_2(Board &board, const std::vector<Coord> &coords, c
 
     bool did_act = false;
 
-    std::string tag;
-    if (board.any_see_each_other(coords, tag)) {
+    if (auto unit = board.any_see_each_other(coords)) {
        for (const Coord &coord : coords) {
-           std::cout << "[SC] " << coord << " x" << value << " [" << tag << color << "]" << std::endl;
+           std::cout << "[SC] " << coord << " x" << value << " [" << tag(*unit) << color << "]" << std::endl;
            board.clear_note_at(coord, value);
        }
        did_act = true;

--- a/analyzer-hiddensingles.cpp
+++ b/analyzer-hiddensingles.cpp
@@ -11,7 +11,7 @@ template<class Set>
 std::optional<Unit> Analyzer::test_hidden_single(const Cell &cell, const Value &value, const Set &set) const {
     if (!cell.isNote()) return std::nullopt;
     if (cell.notes().count() <= 1) return std::nullopt; // either a naked single, or an impossibility
-    if (!cell.check(value)) return std::nullopt;        // note a candidate for value any longer
+    if (!cell.check(value)) return std::nullopt;        // not a candidate for value any longer
 
     for (auto const &other_cell : set) {
         if (other_cell == cell) continue;               // do not consider the current cell

--- a/analyzer-hiddensingles.cpp
+++ b/analyzer-hiddensingles.cpp
@@ -21,7 +21,7 @@ bool Analyzer::test_hidden_single(const Cell &cell, const Value &value, const Se
 
         return false;
     }
-    out_tag.append(set.tag());
+    out_tag.append(tag(set.kind()));
     return true;
 }
 

--- a/analyzer-hiddensingles.cpp
+++ b/analyzer-hiddensingles.cpp
@@ -8,10 +8,10 @@
 #include <algorithm>
 
 template<class Set>
-bool Analyzer::test_hidden_single(const Cell &cell, const Value &value, const Set &set, std::string &out_tag) const {
-    if (!cell.isNote()) return false;
-    if (cell.notes().count() <= 1) return false; // either a naked single, or an impossibility
-    if (!cell.check(value)) return false;        // note a candidate for value any longer
+std::optional<Unit> Analyzer::test_hidden_single(const Cell &cell, const Value &value, const Set &set) const {
+    if (!cell.isNote()) return std::nullopt;
+    if (cell.notes().count() <= 1) return std::nullopt; // either a naked single, or an impossibility
+    if (!cell.check(value)) return std::nullopt;        // note a candidate for value any longer
 
     for (auto const &other_cell : set) {
         if (other_cell == cell) continue;               // do not consider the current cell
@@ -19,10 +19,9 @@ bool Analyzer::test_hidden_single(const Cell &cell, const Value &value, const Se
         if (other_cell.isValue()) continue;             // only considering note cells
         if (!other_cell.notes().check(value)) continue; // this note cell is _not_ a candidate
 
-        return false;
+        return std::nullopt;
     }
-    out_tag.append(tag(set.kind()));
-    return true;
+    return set.kind();
 }
 
 bool Analyzer::find_hidden_singles() {
@@ -36,18 +35,18 @@ bool Analyzer::find_hidden_singles() {
 
         // yes!
         for (auto const &value : cell.notes().values()) { // for each candidate value in this note cell
-            // is this a hidden single?
-            std::string tag;
-            if (!test_hidden_single(cell, value, mBoard.row(cell), tag)
-             && !test_hidden_single(cell, value, mBoard.column(cell), tag)
-             && !test_hidden_single(cell, value, mBoard.nonet(cell), tag)) continue;
+            // is this a hidden single in its row, column, or nonet?
+            auto unit = test_hidden_single(cell, value, mBoard.row(cell));
+            if (!unit) unit = test_hidden_single(cell, value, mBoard.column(cell));
+            if (!unit) unit = test_hidden_single(cell, value, mBoard.nonet(cell));
+            if (!unit) continue;
 
             // yes! but do we already know about it?
             if (std::find_if(mHiddenSingles.begin(), mHiddenSingles.end(),
                        [cell](const auto &entry) { return cell.coord() == entry.coord; }) != mHiddenSingles.end()) continue;
 
             // no! let's record it
-            HiddenSingle hs(cell.coord(), value, tag);
+            HiddenSingle hs(cell.coord(), value, *unit);
             mHiddenSingles.push_back(hs);
             if (sVerbose) std::cout << "  [fHS] " << hs << std::endl;
             did_find = true;
@@ -63,7 +62,7 @@ bool Analyzer::act_on_hidden_single() {
     if (mHiddenSingles.empty()) return did_act;
 
     for (auto const &entry : mHiddenSingles) {
-        std::cout << "[HS] " << entry.coord << " =" << entry.value << " [" << entry.tag << "]" << std::endl;
+        std::cout << "[HS] " << entry.coord << " =" << entry.value << " [" << tag(entry.unit) << "]" << std::endl;
         mBoard.set_value_at(entry.coord, entry.value);
         did_act = true;
     }
@@ -74,5 +73,5 @@ bool Analyzer::act_on_hidden_single() {
 }
 
 std::ostream& operator<<(std::ostream& outs, const Analyzer::HiddenSingle &hs) {
-    return outs << hs.coord << "#" << hs.value << "[" << hs.tag << "]";
+    return outs << hs.coord << "#" << hs.value << "[" << tag(hs.unit) << "]";
 }

--- a/analyzer-lockedcandidates.cpp
+++ b/analyzer-lockedcandidates.cpp
@@ -7,33 +7,8 @@
 
 #include <algorithm>
 
-namespace { // anon
-template<class Set>
-bool would_act_on_set(std::vector<Coord> const &coords, Value const &value, std::string const &expected_tag, Set const &set) {
-    assert(tag(set.kind()) == expected_tag);
-
-    bool would_act = false;
-
-    for (auto const &cell : set) {
-        // is it a note cell?
-        if (!cell.isNote()) continue;
-
-        // yes! but is it a candidate?
-        if (!cell.check(value)) continue;
-
-        // yes! but is it one of the locked candidates?
-        if (std::find(coords.begin(), coords.end(), cell.coord()) != coords.end()) continue;
-
-        would_act = true;
-        break;
-    }
-
-    return would_act;
-}
-}
-
 bool Analyzer::LockedCandidates::operator==(const LockedCandidates &other) const {
-    if (tag != other.tag) return false;
+    if (unit != other.unit) return false;
     if (value != other.value) return false;
     if (coords.size() != other.coords.size()) return false;
     for (const Coord &c : coords) {
@@ -95,7 +70,7 @@ bool Analyzer::find_locked_candidate(const Cell &cell, const Value &value, Set1 
 
     if (would_act) {
         // but is this entry already recorded?
-        LockedCandidates lc(lc_coords, value, std::string(tag(set_to_ignore.kind())));
+        LockedCandidates lc(lc_coords, value, set_to_ignore.kind());
         if (std::find(mLockedCandidates.begin(), mLockedCandidates.end(), lc) != mLockedCandidates.end()) return did_find;
 
         // no! let's record it
@@ -155,7 +130,7 @@ bool Analyzer::act_on_locked_candidate(const LockedCandidates &entry, Set &set) 
         if (!other_cell.check(entry.value)) continue;
 
         // yes! we'll act
-        std::cout << "[LC] " << other_cell.coord() << " x" << entry.value << " [" << entry.tag << "]" << std::endl;
+        std::cout << "[LC] " << other_cell.coord() << " x" << entry.value << " [" << tag(entry.unit) << "]" << std::endl;
         mBoard.clear_note_at(other_cell.coord(), entry.value);
         did_act = true;
     }
@@ -169,15 +144,15 @@ bool Analyzer::act_on_locked_candidate() {
     if (mLockedCandidates.empty()) return did_act;
 
     for (auto const &entry : mLockedCandidates) {
-        switch (entry.tag[0]) {
-        case 'r':
+        switch (entry.unit) {
+        case Unit::Row:
             did_act |= act_on_locked_candidate(entry, mBoard.row(entry.coords.at(0)));
             break;
-        case 'c':
+        case Unit::Column:
             did_act |= act_on_locked_candidate(entry, mBoard.column(entry.coords.at(0)));
             break;
-        case 'n':
-            did_act |=  act_on_locked_candidate(entry, mBoard.nonet(entry.coords.at(0)));
+        case Unit::Nonet:
+            did_act |= act_on_locked_candidate(entry, mBoard.nonet(entry.coords.at(0)));
             break;
         }
     }
@@ -195,6 +170,6 @@ std::ostream& operator<<(std::ostream& outs, const Analyzer::LockedCandidates &l
         is_first = false;
         outs << coord;
     }
-    outs << "}#" << lc.value << "[^" << lc.tag << "]";
+    outs << "}#" << lc.value << "[^" << tag(lc.unit) << "]";
     return outs;
 }

--- a/analyzer-lockedcandidates.cpp
+++ b/analyzer-lockedcandidates.cpp
@@ -9,8 +9,8 @@
 
 namespace { // anon
 template<class Set>
-bool would_act_on_set(std::vector<Coord> const &coords, Value const &value, std::string const &tag, Set const &set) {
-    assert(set.tag() == tag);
+bool would_act_on_set(std::vector<Coord> const &coords, Value const &value, std::string const &expected_tag, Set const &set) {
+    assert(tag(set.kind()) == expected_tag);
 
     bool would_act = false;
 
@@ -95,7 +95,7 @@ bool Analyzer::find_locked_candidate(const Cell &cell, const Value &value, Set1 
 
     if (would_act) {
         // but is this entry already recorded?
-        LockedCandidates lc(lc_coords, value, set_to_ignore.tag());
+        LockedCandidates lc(lc_coords, value, std::string(tag(set_to_ignore.kind())));
         if (std::find(mLockedCandidates.begin(), mLockedCandidates.end(), lc) != mLockedCandidates.end()) return did_find;
 
         // no! let's record it

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -123,12 +123,12 @@ bool Analyzer::act_on_naked_pair(const NakedPair &entry, Set &set) {
 
         if (other_cell.check(entry.values.first)) {
             mBoard.clear_note_at(other_cell.coord(), entry.values.first);
-            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.first << " [" << set.tag() << "]" << std::endl;
+            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.first << " [" << tag(set.kind()) << "]" << std::endl;
             did_act = true;
         }
         if (other_cell.check(entry.values.second)) {
             mBoard.clear_note_at(other_cell.coord(), entry.values.second);
-            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.second << " [" << set.tag() << "]" << std::endl;
+            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.second << " [" << tag(set.kind()) << "]" << std::endl;
             did_act = true;
         }
     }

--- a/analyzer-swordfish.cpp
+++ b/analyzer-swordfish.cpp
@@ -193,7 +193,7 @@ bool Analyzer::find_swordfish() {
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::act_on_swordfish(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2, const CandidateSet &cset3,
-                                                     const EliminationSet &eset, const std::string &tag) {
+                                                     const EliminationSet &eset, Unit unit) {
     bool did_act = false;
 
     for (auto &cell : eset) {
@@ -209,7 +209,7 @@ bool Analyzer::act_on_swordfish(const Value &value, const CandidateSet &cset1, c
         if (cset3.contains(cell)) continue;
 
         // Eliminate the candidate
-        std::cout << "[SF] " << cell.coord() << " x" << value << " [" << tag << "]" << std::endl;
+        std::cout << "[SF] " << cell.coord() << " x" << value << " [" << tag(unit) << "]" << std::endl;
         mBoard.clear_note_at(cell.coord(), value);
         did_act = true;
     }
@@ -251,7 +251,7 @@ bool Analyzer::act_on_swordfish() {
 
         // Eliminate from each column
         for (const auto* col_ptr : elimination_columns) {
-            did_act |= act_on_swordfish(entry.value, row1, row2, row3, *col_ptr, "c");
+            did_act |= act_on_swordfish(entry.value, row1, row2, row3, *col_ptr, Unit::Column);
         }
     } else {
         // Column-based Swordfish: the pattern is in three columns, eliminate from rows
@@ -279,7 +279,7 @@ bool Analyzer::act_on_swordfish() {
 
         // Eliminate from each row
         for (const auto* row_ptr : elimination_rows) {
-            did_act |= act_on_swordfish(entry.value, col1, col2, col3, *row_ptr, "r");
+            did_act |= act_on_swordfish(entry.value, col1, col2, col3, *row_ptr, Unit::Row);
         }
     }
 

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -162,7 +162,7 @@ bool Analyzer::find_xwings() {
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::act_on_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                                const EliminationSet &eset, const std::string &tag) {
+                                                const EliminationSet &eset, Unit unit) {
     bool did_act = false;
 
     for (auto &cell : eset) {
@@ -172,7 +172,7 @@ bool Analyzer::act_on_xwing(const Value &value, const CandidateSet &cset1, const
         assert(cell.isNote());
         assert(cell.check(value));
 
-        std::cout << "[XW] " << cell.coord() << " x" << value << " [" << tag << "]" << std::endl;
+        std::cout << "[XW] " << cell.coord() << " x" << value << " [" << tag(unit) << "]" << std::endl;
         mBoard.clear_note_at(cell.coord(), value);
         did_act = true;
     }
@@ -195,9 +195,9 @@ bool Analyzer::act_on_xwing() {
         auto diagonal_column_eliminates = candidates(mBoard.column(entry.diagonal), entry.value);
 
         did_act |= act_on_xwing(entry.value, anchor_row_candidates, diagonal_row_candidates,
-                                           anchor_column_eliminates, "c");
+                                           anchor_column_eliminates, Unit::Column);
         did_act |= act_on_xwing(entry.value, anchor_row_candidates, diagonal_row_candidates,
-                                           diagonal_column_eliminates, "c");
+                                           diagonal_column_eliminates, Unit::Column);
     } else {
         // Column-based X-Wing: eliminate candidates from the two rows
         auto anchor_column_candidates = candidates(mBoard.column(entry.anchor), entry.value);
@@ -206,9 +206,9 @@ bool Analyzer::act_on_xwing() {
         auto diagonal_row_eliminates = candidates(mBoard.row(entry.diagonal), entry.value);
 
         did_act |= act_on_xwing(entry.value, anchor_column_candidates, diagonal_column_candidates,
-                                           anchor_row_eliminates, "r");
+                                           anchor_row_eliminates, Unit::Row);
         did_act |= act_on_xwing(entry.value, anchor_column_candidates, diagonal_column_candidates,
-                                           diagonal_row_eliminates, "r");
+                                           diagonal_row_eliminates, Unit::Row);
     }
     mXWings.clear();
 

--- a/analyzer-xychain.cpp
+++ b/analyzer-xychain.cpp
@@ -39,9 +39,8 @@ size_t Analyzer::test_xychain(const Value &value, const std::vector<Coord> &chai
         if (std::find(chain.begin(), chain.end(), cell.coord()) != chain.end()) continue;
 
         // no! but can it see both ends?
-        std::string tag;
-        if (!mBoard.see_each_other(cell.coord(), chain.front(), tag)) continue;
-        if (!mBoard.see_each_other(cell.coord(), chain.back(), tag)) continue;
+        if (!mBoard.see_each_other(cell.coord(), chain.front())) continue;
+        if (!mBoard.see_each_other(cell.coord(), chain.back())) continue;
 
         // yes! count it
         num_elim++;
@@ -193,8 +192,7 @@ bool Analyzer::act_on_xychain(const XYChain &entry, const Set &chain_front_set) 
         if (std::find(entry.chain.begin(), entry.chain.end(), cell.coord()) != entry.chain.end()) continue;
 
         // no! but can it see the other end of the chain?
-        std::string tag;
-        if (!mBoard.see_each_other(cell.coord(), entry.chain.back(), tag)) continue;
+        if (!mBoard.see_each_other(cell.coord(), entry.chain.back())) continue;
 
         // yes! ELIMINATE!
         std::cout << "[XY] " << cell.coord() << " x" << entry.value

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -23,8 +23,7 @@ namespace { // anon
             if (cell.coord() == wing2.coord()) continue;
             if (!cell.check(value)) continue;
 
-            std::string tag;
-            if (board.see_each_other(cell.coord(), wing2.coord(), tag)) {
+            if (board.see_each_other(cell.coord(), wing2.coord())) {
                 would_act = true;
                 break;
             }
@@ -192,8 +191,7 @@ bool Analyzer::act_on_ywing(const YWing &entry, const Set &wing1_set) {
         if (cell.coord() == entry.wings.second) continue;
         if (!cell.check(entry.value)) continue;
 
-        std::string tag;
-        if (mBoard.see_each_other(cell.coord(), entry.wings.second, tag)) {
+        if (mBoard.see_each_other(cell.coord(), entry.wings.second)) {
             std::cout << "[YW] " << cell.coord() << " x" << entry.value << std::endl;
             mBoard.clear_note_at(cell.coord(), entry.value);
             did_act = true;

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -22,7 +22,7 @@ void Analyzer::filter_notes(Cell &cell, const Set &set) {
             if (!cell.check(other_cell.value())) continue;
 
             if (sVerbose) std::cout << "  [FNn] " << cell.coord() << " x" << other_cell.value()
-                      << " " << set.tag() << "(" << other_cell.coord() << ")" << std::endl;
+                      << " " << tag(set.kind()) << "(" << other_cell.coord() << ")" << std::endl;
             mBoard.clear_note_at(cell.coord(), other_cell.value());
         }
     }
@@ -36,7 +36,7 @@ void Analyzer::filter_notes(Cell &cell, const Set &set) {
             if (!other_cell.check(cell.value())) continue;
 
             if (sVerbose) std::cout << "  [FNv] " << other_cell.coord() << " x" << cell.value()
-                      << " " << set.tag() << "(" << cell.coord() << ")" << std::endl;
+                      << " " << tag(set.kind()) << "(" << cell.coord() << ")" << std::endl;
             mBoard.clear_note_at(other_cell.coord(), cell.value());
         }
     }

--- a/analyzer.h
+++ b/analyzer.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <unordered_map>
 #include <memory>
+#include <optional>
 
 class Analyzer {
 public:
@@ -76,14 +77,14 @@ private:
     struct HiddenSingle {
         Coord coord;
         Value value;
-        std::string tag;
+        Unit unit;
     };
     friend std::ostream& operator<<(std::ostream& outs, const HiddenSingle &);
     std::vector<HiddenSingle> mHiddenSingles;
 
     // find
     template<class Set>
-    bool test_hidden_single(const Cell &, const Value &, const Set &, std::string &) const;
+    std::optional<Unit> test_hidden_single(const Cell &, const Value &, const Set &) const;
     bool find_hidden_singles();
 
     // act
@@ -117,7 +118,7 @@ private:
     struct LockedCandidates {
         std::vector<Coord> coords;
         Value value;
-        std::string tag;
+        Unit unit;
 
         bool operator==(const LockedCandidates &other) const;
     };
@@ -179,7 +180,7 @@ private:
     // act
     template<class CandidateSet, class EliminationSet>
     bool act_on_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                          const EliminationSet &eset, const std::string &tag);
+                                          const EliminationSet &eset, Unit unit);
     bool act_on_xwing();
 
 private:
@@ -203,7 +204,7 @@ private:
     // act
     template<class CandidateSet, class EliminationSet>
     bool act_on_swordfish(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2, const CandidateSet &cset3,
-                                              const EliminationSet &eset, const std::string &tag);
+                                              const EliminationSet &eset, Unit unit);
     bool act_on_swordfish();
 
 private:

--- a/board.cpp
+++ b/board.cpp
@@ -288,15 +288,6 @@ const Nonet &Board::nonet(const Coord &coord) const {
     return mNonets.at(nonetRow + nonetCol / 3);
 }
 
-const char *tag(Unit unit) {
-    switch (unit) {
-        case Unit::Row:    return "r";
-        case Unit::Column: return "c";
-        case Unit::Nonet:  return "n";
-    }
-    return "?"; // unreachable; silences -Wreturn-type
-}
-
 std::optional<Unit> Board::see_each_other(const Coord &coord1, const Coord &coord2) const {
     if      (row(coord1)    == row(coord2))    return Unit::Row;
     else if (column(coord1) == column(coord2)) return Unit::Column;

--- a/board.cpp
+++ b/board.cpp
@@ -288,30 +288,33 @@ const Nonet &Board::nonet(const Coord &coord) const {
     return mNonets.at(nonetRow + nonetCol / 3);
 }
 
-bool Board::see_each_other(const Coord &coord1, const Coord &coord2, std::string &out_tag) const {
-    bool did_see_each_other = false;
-
-    if      (row(coord1)    == row(coord2))    { did_see_each_other = true; out_tag.append("r"); }
-    else if (column(coord1) == column(coord2)) { did_see_each_other = true; out_tag.append("c"); }
-    else if (nonet(coord1)  == nonet(coord2))  { did_see_each_other = true; out_tag.append("n"); }
-
-    return did_see_each_other;
+const char *tag(Unit unit) {
+    switch (unit) {
+        case Unit::Row:    return "r";
+        case Unit::Column: return "c";
+        case Unit::Nonet:  return "n";
+    }
+    return "?"; // unreachable; silences -Wreturn-type
 }
 
-bool Board::any_see_each_other(const std::vector<Coord> &coords, std::string &out_tag) const {
-    bool did_any_see_each_other = false;
+std::optional<Unit> Board::see_each_other(const Coord &coord1, const Coord &coord2) const {
+    if      (row(coord1)    == row(coord2))    return Unit::Row;
+    else if (column(coord1) == column(coord2)) return Unit::Column;
+    else if (nonet(coord1)  == nonet(coord2))  return Unit::Nonet;
 
+    return std::nullopt;
+}
+
+std::optional<Unit> Board::any_see_each_other(const std::vector<Coord> &coords) const {
     for (size_t i = 0; i < coords.size(); ++i) {
         for (size_t j = i + 1; j < coords.size(); ++j) {
-            if (see_each_other(coords[i], coords[j], out_tag)) {
-                did_any_see_each_other = true;
-                break;
+            if (auto unit = see_each_other(coords[i], coords[j])) {
+                return unit;
             }
         }
-        if (did_any_see_each_other) break;
     }
 
-    return did_any_see_each_other;
+    return std::nullopt;
 }
 
 std::ostream& operator<<(std::ostream& outs, const Board &b) {

--- a/board.h
+++ b/board.h
@@ -14,6 +14,12 @@ class Row;
 class Column;
 class Nonet;
 
+// Identifies which kind of unit relates two cells that see each other.
+enum class Unit { Row, Column, Nonet };
+
+// Single-character display tag for a unit: "r" / "c" / "n".
+const char *tag(Unit);
+
 // Parse a 3-character "row,column,value" triple, each a digit 1-9, into
 // zero-based row/column indices and a Value. Returns false (leaving the
 // out-parameters unspecified) if the entry is the wrong length or any field
@@ -59,15 +65,16 @@ public:
     const std::vector<Column> &columns() const { return mColumns; }
     const std::vector<Nonet> &nonets() const { return mNonets; }
 
-    // are these two coords in the same row, column or nonet?
-    bool see_each_other(const Coord &, const Coord &, std::string &out_tag) const;
+    // are these two coords in the same row, column or nonet? returns the shared
+    // unit kind, or nullopt if they do not see each other.
+    std::optional<Unit> see_each_other(const Coord &, const Coord &) const;
     bool see_each_other(const Cell &c1, const Cell &c2) const {
-        std::string tag;
-        return see_each_other(c1.coord(), c2.coord(), tag);
+        return see_each_other(c1.coord(), c2.coord()).has_value();
     }
 
-    // do any two of the passed coords see each other?
-    bool any_see_each_other(const std::vector<Coord> &, std::string &out_tag) const;
+    // do any two of the passed coords see each other? returns the unit shared by
+    // the first such pair found, or nullopt if none do.
+    std::optional<Unit> any_see_each_other(const std::vector<Coord> &) const;
 
     friend std::ostream& operator<< (std::ostream& outs, const Board &);
     friend class Row;

--- a/board.h
+++ b/board.h
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <cstddef>
 #include <memory>
+#include <optional>
 
 class Row;
 class Column;

--- a/board.h
+++ b/board.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string_view>
 
 class Row;
 class Column;
@@ -19,7 +20,14 @@ class Nonet;
 enum class Unit { Row, Column, Nonet };
 
 // Single-character display tag for a unit: "r" / "c" / "n".
-const char *tag(Unit);
+constexpr std::string_view tag(Unit unit) {
+    switch (unit) {
+        case Unit::Row:    return "r";
+        case Unit::Column: return "c";
+        case Unit::Nonet:  return "n";
+    }
+    return "?"; // unreachable; silences -Wreturn-type
+}
 
 // Parse a 3-character "row,column,value" triple, each a digit 1-9, into
 // zero-based row/column indices and a Value. Returns false (leaving the

--- a/column.h
+++ b/column.h
@@ -19,7 +19,7 @@ public:
         , mCellStart(index) // line 0, column 'index'
         , mCellSentinel(index + board.height * board.width) { }
 
-    std::string tag() const { return "c"; }
+    std::string tag() const { return ::tag(Unit::Column); }
 
     class Iterator {
     public:

--- a/column.h
+++ b/column.h
@@ -19,7 +19,7 @@ public:
         , mCellStart(index) // line 0, column 'index'
         , mCellSentinel(index + board.height * board.width) { }
 
-    std::string tag() const { return ::tag(Unit::Column); }
+    Unit kind() const { return Unit::Column; }
 
     class Iterator {
     public:

--- a/nonet.h
+++ b/nonet.h
@@ -21,7 +21,7 @@ public:
                  (coord.column() / width)  * width)
         , mSentinel(mCoord.row() + height, mCoord.column()) { }
 
-    std::string tag() const { return "n"; }
+    std::string tag() const { return ::tag(Unit::Nonet); }
 
     class Iterator {
     public:

--- a/nonet.h
+++ b/nonet.h
@@ -21,7 +21,7 @@ public:
                  (coord.column() / width)  * width)
         , mSentinel(mCoord.row() + height, mCoord.column()) { }
 
-    std::string tag() const { return ::tag(Unit::Nonet); }
+    Unit kind() const { return Unit::Nonet; }
 
     class Iterator {
     public:

--- a/row.h
+++ b/row.h
@@ -19,7 +19,7 @@ public:
         , mCellStart(index * board.width)
         , mCellSentinel(index * board.width + board.width) { }
 
-    std::string tag() const { return "r"; }
+    std::string tag() const { return ::tag(Unit::Row); }
 
     class Iterator {
     public:

--- a/row.h
+++ b/row.h
@@ -19,7 +19,7 @@ public:
         , mCellStart(index * board.width)
         , mCellSentinel(index * board.width + board.width) { }
 
-    std::string tag() const { return ::tag(Unit::Row); }
+    Unit kind() const { return Unit::Row; }
 
     class Iterator {
     public:


### PR DESCRIPTION
## Summary

Closes item 2 of #12, and extends it: every place that tracked a row/column/nonet as a `"r"`/`"c"`/`"n"` string now carries a type-safe `enum class Unit { Row, Column, Nonet }`, rendering to a string only at output time. What started as a fix to `Board::see_each_other`'s out-string parameter grew into a full migration across the analyzer, since the same stringly-typed pattern recurred in the stored findings.

## Changes

**Board / unit types**
- `enum class Unit` plus a free `constexpr std::string_view tag(Unit)` (single source of the `"r"/"c"/"n"` mapping) in `board.h`.
- `see_each_other` / `any_see_each_other` return `std::optional<Unit>` instead of `bool` + a `std::string &out_tag` out-parameter. The `see_each_other(Cell, Cell)` overload keeps its `bool` shape via `.has_value()`.
- `Row`/`Column`/`Nonet` expose `kind()` (returning `Unit`) instead of a `tag()` member. This separates a unit's identity from its presentation and removes the free-vs-member `tag()` name collision at its root.

**Analyzer**
- `HiddenSingle` and `LockedCandidates` store `Unit unit` instead of `std::string tag`; `operator==`, the act dispatch (`switch (entry.unit)` rather than `switch (entry.tag[0])`), and output use the enum directly.
- `test_hidden_single` returns `std::optional<Unit>` instead of `bool` + out-string, mirroring `see_each_other`; the caller chains the three units through the optional.
- `act_on_xwing` / `act_on_swordfish` take a `Unit`; callers pass `Unit::Row`/`Unit::Column` instead of `"r"`/`"c"` literals.
- Removed `would_act_on_set`: a never-instantiated anon-namespace template whose only remaining stringly-typed tag lived there. Its logic is already inlined verbatim in `find_locked_candidate`.

`print_section`'s `const char *tag` is a generic section label (NS/HS/...), not a unit, and is left as-is.

## Testing

- `make test` — 80/80 pass
- `make unit` — all checks pass
- Clean build under `-Wall -Werror`
- **Output verified byte-for-byte unchanged**: all 16 board fixtures from the test harness produce identical verbose (`r`/`p`/`c`) output before and after the change.

## Net effect

Removes the throwaway string allocations on the `see_each_other` hot paths, eliminates stringly-typed unit storage throughout the analyzer, and makes the unit kind a closed, type-checked set. After this lands, #12 can be closed entirely (items 1 and 3 went in via #16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)