### PR TITLE
Code-review cleanups: nullptr, copyright typo, dead include

### DIFF
--- a/analyzer-hiddenpairs.cpp
+++ b/analyzer-hiddenpairs.cpp
@@ -17,7 +17,7 @@ bool Analyzer::find_hidden_pair(const Cell &cell, const Value &v1, const Value &
 
     // can we find another note cell with the same pair in the same set,
     // but no other cell with either candidate in the set?
-    Cell *ppair_cell = NULL; // "the" other potential candidate
+    Cell *ppair_cell = nullptr; // "the" other potential candidate
     bool condition_met = true;
 
     for (auto &other_cell : set) {

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Bertrand Mollivier Toublet
+// Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
 #include "analyzer.h"

--- a/board.cpp
+++ b/board.cpp
@@ -6,7 +6,6 @@
 #include "column.h"
 #include "nonet.h"
 #include "cell.h"
-#include "verbose.h"
 
 #include <array>
 #include <cassert>


### PR DESCRIPTION
Addresses three code-review nits, all low-risk:

- **analyzer-hiddenpairs.cpp**: `NULL` → `nullptr` (the only `NULL` in the tree; everything else already uses `nullptr`)
- **analyzer-ywing.cpp**: fix copyright typo "Mollivier" → "Mollinier" (only occurrence)
- **board.cpp**: drop unused `#include "verbose.h"` (`sVerbose` is never referenced in this TU; flagged by clangd include-cleaner)

## Verification
- `make` clean under `-Wall -Werror`
- `make test` → passed: 80, failed: 0
- `make unit` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)