### PR TITLE
Notes::values(): return inline ValueList, drop per-call heap alloc (#17)

### DIFF
--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -48,10 +48,12 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
     if (c2.notes().count() != 2) return false;
 
     // yes! but are they the same pairs of candidates?
-    auto v11 = c1.notes().values().at(0);
-    auto v12 = c1.notes().values().at(1);
-    auto v21 = c2.notes().values().at(0);
-    auto v22 = c2.notes().values().at(1);
+    auto c1v = c1.notes().values();
+    auto c2v = c2.notes().values();
+    auto v11 = c1v.at(0);
+    auto v12 = c1v.at(1);
+    auto v21 = c2v.at(0);
+    auto v22 = c2v.at(1);
 
     if (!((v11 == v21 && v12 == v22) || (v11 == v22 && v12 == v21))) return false;
 
@@ -71,7 +73,8 @@ bool Analyzer::find_naked_pair(const Cell &cell, const Set &set) {
         if (!test_naked_pair(cell, pair_cell, set)) continue;
 
         // yes! but is it already recorded?
-        NakedPair np({cell.coord(), pair_cell.coord()}, {cell.notes().values().at(0), cell.notes().values().at(1)});
+        auto cellv = cell.notes().values();
+        NakedPair np({cell.coord(), pair_cell.coord()}, {cellv.at(0), cellv.at(1)});
         if (std::find(mNakedPairs.begin(), mNakedPairs.end(), np) != mNakedPairs.end()) continue;
 
         // no! let's record it

--- a/analyzer-xychain.cpp
+++ b/analyzer-xychain.cpp
@@ -169,8 +169,9 @@ bool Analyzer::find_xychains() {
         if (cell.notes().count() != 2) continue;
 
         // yes! attempt to build chains from this cell for each candidate value
-        did_find |= find_xychain(cell, cell.notes().values()[0]);
-        did_find |= find_xychain(cell, cell.notes().values()[1]);
+        auto values = cell.notes().values();
+        did_find |= find_xychain(cell, values[0]);
+        did_find |= find_xychain(cell, values[1]);
     }
 
     return did_find;

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -65,12 +65,12 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     // set as the pivot are skipped (no more than one shared).
 
     // which value does wing1 share with pivot?
-    const auto &w1 = wing1.notes().values();
+    const auto w1 = wing1.notes().values();
     assert(pivot.check(w1[0]) != pivot.check(w1[1]));
     Value wing1_shared = pivot.check(w1[0]) ? w1[0] : w1[1];
 
     // which value does wing2 share with pivot?
-    const auto &w2 = wing2.notes().values();
+    const auto w2 = wing2.notes().values();
     assert(pivot.check(w2[0]) != pivot.check(w2[1]));
     Value wing2_shared = pivot.check(w2[0]) ? w2[0] : w2[1];
 
@@ -94,6 +94,8 @@ namespace {
     void select_wing_candidates(const Cell &pivot, const Set &set, std::unordered_set<Cell> &wing_candidates) {
         assert(set.contains(pivot));
 
+        const auto pivot_values = pivot.notes().values();
+
         for (auto const &cell : set) {
             // is this another cell than the pivot?
             if (cell == pivot) continue;
@@ -105,10 +107,11 @@ namespace {
             if (cell.notes().count() != 2) continue;
 
             // yes! but is one of the candidates also a candidate for pivot?
-            if (!pivot.check(cell.notes().values()[0]) && !pivot.check(cell.notes().values()[1])) continue;
+            const auto cell_values = cell.notes().values();
+            if (!pivot.check(cell_values[0]) && !pivot.check(cell_values[1])) continue;
 
             // yes! but are both candidates not candidates for pivot?
-            if (pivot.notes().values() == cell.notes().values()) continue;
+            if (pivot_values == cell_values) continue;
 
             // yes! ok, this is a bona fide wing candidate; record it
             // unordered_set automatically handles duplicates

--- a/cell.cpp
+++ b/cell.cpp
@@ -19,8 +19,8 @@ bool Notes::set(const Value &v, bool set) {
     return note;
 }
 
-std::vector<Value> Notes::values() const {
-    std::vector<Value> v;
+ValueList Notes::values() const {
+    ValueList v;
     for (Value value : value_range()) {
         if (check(value)) v.push_back(value);
     }

--- a/cell.h
+++ b/cell.h
@@ -3,13 +3,13 @@
 #pragma once
 
 #include <functional>
+#include <array>
 #include <cassert>
 #include <bit>
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <type_traits>
-#include <vector>
 #include <ranges>
 
 #include "coord.h"
@@ -36,6 +36,38 @@ inline auto value_range() {
 
 class Cell;
 
+// The candidates of a Notes, materialized inline with no heap allocation. A cell
+// holds at most nine candidates, so a fixed nine-slot array plus a count covers
+// every case while staying trivially copyable. This is a drop-in for the
+// std::vector<Value> that Notes::values() used to return, exposing exactly what
+// the analyzer call sites need: range iteration, indexing, size, and equality.
+// Values are stored ascending (values() fills it in value_range order), so
+// equality between two lists is a positional candidate-set comparison.
+class ValueList {
+public:
+    using const_iterator = const Value *;
+
+    void push_back(const Value &v) { assert(mCount < mData.size()); mData[mCount++] = v; }
+
+    size_t size() const { return mCount; }
+
+    Value operator[](size_t i) const { assert(i < mCount); return mData[i]; }
+    Value at(size_t i) const { return (*this)[i]; }
+
+    const_iterator begin() const { return mData.data(); }
+    const_iterator end() const { return mData.data() + mCount; }
+
+    bool operator==(const ValueList &other) const {
+        if (mCount != other.mCount) return false;
+        for (size_t i = 0; i < mCount; ++i) if (mData[i] != other.mData[i]) return false;
+        return true;
+    }
+
+private:
+    std::array<Value, 9> mData {};
+    size_t mCount = 0;
+};
+
 // The nine candidate flags packed into a bitmask: bit (v - 1) is set when v is
 // still a candidate. A plain integer keeps Notes (and therefore Cell) trivially
 // copyable, with no per-cell heap allocation.
@@ -51,7 +83,7 @@ public:
     bool set_all(bool set) { mNotes = set ? kAllCandidates : 0; return true; }
 
     size_t count() const { return std::popcount(mNotes); }
-    std::vector<Value> values() const;
+    ValueList values() const;
 
     // For a two-candidate cell, the candidate that isn't v. Clearing v's bit
     // leaves a single bit standing; its position (0-based) is the value minus 1.


### PR DESCRIPTION
## Problem (#17)

`Notes::values()` returned a freshly heap-allocated `std::vector<Value>` on every call, and it is called heavily in the analyzer's inner loops. #16 removed the per-`Cell`-copy allocation but left this comparable (and more frequent) allocation right next to it on the hot path. Y-Wing alone hits it ~a dozen times per wing pair.

## Change

- **New `ValueList`** (`cell.h`): a fixed nine-slot `std::array<Value>` plus a count. No heap, trivially copyable, and a drop-in over exactly the API the call sites use: range iteration (random-access `const Value*`), `operator[]`/`at`, `size`, and `operator==`. Candidates stay ascending (filled in `value_range` order), so the Y-Wing `==` comparison keeps its positional candidate-set semantics.
- `Notes::values()` now returns `ValueList`; body unchanged.
- Dropped the now-unused `<vector>` include from `cell.h` (verified nothing depended on it transitively); added `<array>`.

### Call-site cleanups (issue's third recommendation)

- `nakedpairs`, `xychain`, `ywing` called `values()` two-to-four times in a row; cache to a local instead.
- `select_wing_candidates`: hoisted the loop-invariant `pivot.notes().values()` out of the per-cell loop.
- `test_ywing`: `w1`/`w2` are now plain values rather than `const auto &` bound to a temporary.

## Verification

- Clean build under `-Wall -Werror`.
- `make test`: **80/80** integration tests pass. `make unit`: all whitebox checks pass.
- Before/after (worktree baseline, best-of-5 over a 150× hard-puzzle workload): 3.05s → 2.97s (~2.6%). Modest in wall-clock since total runtime is dominated by other analyzer work, but the hot-path heap traffic is gone, which is what the issue targeted.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)