### PR TITLE
LockedCandidates::operator<<: write coord separator to outs, not std::cout

### DIFF
--- a/analyzer-lockedcandidates.cpp
+++ b/analyzer-lockedcandidates.cpp
@@ -166,7 +166,7 @@ std::ostream& operator<<(std::ostream& outs, const Analyzer::LockedCandidates &l
     outs << "{";
     bool is_first = true;
     for (auto const &coord : lc.coords) {
-        if (!is_first) { std::cout << ","; }
+        if (!is_first) { outs << ","; }
         is_first = false;
         outs << coord;
     }


### PR DESCRIPTION
## Summary
Fixes an outright defect in `LockedCandidates::operator<<` (`analyzer-lockedcandidates.cpp:169`): the comma separator between coordinates was written to `std::cout` instead of the target stream `outs`.

In the REPL this looked correct because the surrounding text also goes to stdout, but formatting `LockedCandidates` to any other stream (e.g. a `stringstream` in a test) dropped the commas from the result and scattered them onto stdout instead.

One-character fix: `std::cout` → `outs`.

## Testing
- `make` builds clean (`-Wall -Werror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)