### PR TITLE
X-Wing: delete the dead test_xwing, keep find_xwing inline, add whitebox tests

### DIFF
--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -47,7 +47,11 @@ bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const
     // yes -- so the four corners must line up: both base lines' first candidate
     // in eset1, both their second in eset2. This relies on candidates() yielding
     // each line's cells in a consistent cross-line order, so index [0] names the
-    // eset1 side and [1] the eset2 side for both base lines.
+    // eset1 side and [1] the eset2 side for both base lines. A violation could
+    // only ever cost a false negative (a missed pattern), never a wrong
+    // elimination -- returning true still requires all four real corners. The
+    // production caller find_xwing asserts the order holds for its construction
+    // (the crossed-corner assert at its call site).
 
     // does eliminates1 contain the first cell in candidates1?
     if (std::find(eliminates1.begin(), eliminates1.end(), candidates1[0]) == eliminates1.end()) return false;

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -36,12 +36,13 @@ bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const
     auto candidates2 = candidates(cset2, value);
     if (candidates2.size() != 2) return false;
 
-    // yes, but are there at least two candidates in both eset1 and eset2?
+    // yes, but is the rectangle actionable -- does either cross line hold more
+    // than its two corners, so there is a third candidate to eliminate? (A lower
+    // bound of two needs no separate check: the containment tests below require
+    // each cross line to hold both its corners, which are distinct cells whenever
+    // cset1 != cset2 -- the only way find_xwing calls this.)
     auto eliminates1 = candidates(eset1, value);
     auto eliminates2 = candidates(eset2, value);
-    if (eliminates1.size() < 2 || eliminates2.size() < 2) return false;
-
-    // yes, but are there more than two candidates in eset1 or eset 2?
     if (eliminates1.size() <= 2 && eliminates2.size() <= 2) return false;
 
     // yes -- so the four corners must line up: both base lines' first candidate

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -44,7 +44,12 @@ bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const
     // yes, but are there more than two candidates in eset1 or eset 2?
     if (eliminates1.size() <= 2 && eliminates2.size() <= 2) return false;
 
-    // yes, but does eliminates1 contain the first cell in candidates1?
+    // yes -- so the four corners must line up: both base lines' first candidate
+    // in eset1, both their second in eset2. This relies on candidates() yielding
+    // each line's cells in a consistent cross-line order, so index [0] names the
+    // eset1 side and [1] the eset2 side for both base lines.
+
+    // does eliminates1 contain the first cell in candidates1?
     if (std::find(eliminates1.begin(), eliminates1.end(), candidates1[0]) == eliminates1.end()) return false;
 
     // yes, but does eliminates2 contain the second cell in candidates1?

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -25,32 +25,36 @@ namespace {
     }
 }
 
-// The candidate cells of the two base lines are passed in (the caller has
-// already built them), so this only materialises the cross lines' candidate
-// lists -- and only once the cheap geometric checks have confirmed a rectangle,
-// keeping test_xwing's own rejection paths allocation-free.
-template<class EliminationSet>
-bool Analyzer::test_xwing(const Value &value, const std::vector<Cell> &candidates1, const std::vector<Cell> &candidates2,
+template<class CandidateSet, class EliminationSet>
+bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const CandidateSet &cset2,
                                               const EliminationSet &eset1, const EliminationSet &eset2) const {
-    // are there exactly two candidates for value in each base line?
+    // are there exactly two candidates for value in cset1?
+    auto candidates1 = candidates(cset1, value);
     if (candidates1.size() != 2) return false;
+
+    // yes, but are there exactly two candidates for value in cset2?
+    auto candidates2 = candidates(cset2, value);
     if (candidates2.size() != 2) return false;
 
-    // yes, but do both base lines place their candidates in the same two cross
-    // lines? The cells are already value-candidates, so geometric membership in a
-    // cross line is equivalent to being one of its value-candidates -- no need to
-    // materialise the cross lines' candidate lists just to test containment.
-    if (!eset1.contains(candidates1[0])) return false;
-    if (!eset2.contains(candidates1[1])) return false;
-    if (!eset1.contains(candidates2[0])) return false;
-    if (!eset2.contains(candidates2[1])) return false;
-
-    // yes, a rectangle -- but is it actionable? The four corners already sit in
-    // the two cross lines, so each holds at least two candidates; at least one
-    // must hold a third for anything to be eliminated.
+    // yes, but are there at least two candidates in both eset1 and eset2?
     auto eliminates1 = candidates(eset1, value);
     auto eliminates2 = candidates(eset2, value);
+    if (eliminates1.size() < 2 || eliminates2.size() < 2) return false;
+
+    // yes, but are there more than two candidates in eset1 or eset 2?
     if (eliminates1.size() <= 2 && eliminates2.size() <= 2) return false;
+
+    // yes, but does eliminates1 contain the first cell in candidates1?
+    if (std::find(eliminates1.begin(), eliminates1.end(), candidates1[0]) == eliminates1.end()) return false;
+
+    // yes, but does eliminates2 contain the second cell in candidates1?
+    if (std::find(eliminates2.begin(), eliminates2.end(), candidates1[1]) == eliminates2.end()) return false;
+
+    // yes, but does eliminates1 contain the first cell in candidates2?
+    if (std::find(eliminates1.begin(), eliminates1.end(), candidates2[0]) == eliminates1.end()) return false;
+
+    // yes, but does eliminates2 contain the second cell in candidates2?
+    if (std::find(eliminates2.begin(), eliminates2.end(), candidates2[1]) == eliminates2.end()) return false;
 
     return true;
 }
@@ -58,8 +62,8 @@ bool Analyzer::test_xwing(const Value &value, const std::vector<Cell> &candidate
 // Explicit instantiations: test_xwing's only in-TU callers are find_xwing, where
 // it is inlined, so without these GCC emits no standalone symbol and the unit
 // test (which calls it across translation units via AnalyzerTest) fails to link.
-template bool Analyzer::test_xwing<Row>(const Value &, const std::vector<Cell> &, const std::vector<Cell> &, const Row &, const Row &) const;
-template bool Analyzer::test_xwing<Column>(const Value &, const std::vector<Cell> &, const std::vector<Cell> &, const Column &, const Column &) const;
+template bool Analyzer::test_xwing<Row, Column>(const Value &, const Row &, const Row &, const Column &, const Column &) const;
+template bool Analyzer::test_xwing<Column, Row>(const Value &, const Column &, const Column &, const Row &, const Row &) const;
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset, const std::vector<CandidateSet> &csets, bool by_row) {
@@ -104,7 +108,7 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
                  && other_eset.contains(other_cset_candidates[0])));
 
         // is this a valid XWing pattern anchored on (cset, eset)?
-        if (!test_xwing(value, cset_candidates, other_cset_candidates, eset, other_eset)) continue;
+        if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
 
         // yes! take the diagonal corner: the other cset's candidate in the
         // diagonal eset, which test_xwing already verified lies there

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -55,6 +55,12 @@ bool Analyzer::test_xwing(const Value &value, const std::vector<Cell> &candidate
     return true;
 }
 
+// Explicit instantiations: test_xwing's only in-TU callers are find_xwing, where
+// it is inlined, so without these GCC emits no standalone symbol and the unit
+// test (which calls it across translation units via AnalyzerTest) fails to link.
+template bool Analyzer::test_xwing<Row>(const Value &, const std::vector<Cell> &, const std::vector<Cell> &, const Row &, const Row &) const;
+template bool Analyzer::test_xwing<Column>(const Value &, const std::vector<Cell> &, const std::vector<Cell> &, const Column &, const Column &) const;
+
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset, const std::vector<CandidateSet> &csets, bool by_row) {
     assert(cell.isNote());

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -91,11 +91,20 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         // subsequent csets only
         if (!(cset < other_cset)) continue;
 
+        // Invariant: candidates() yields cells in a consistent cross-line order,
+        // so a two-candidate partner can only align with our anchor's corners,
+        // never cross them. test_xwing reports a crossed config as "no" (and we
+        // skip it); assert the impossibility here so a broken ordering invariant
+        // aborts a debug build rather than silently dropping a real pattern.
+        auto other_cset_candidates = candidates(other_cset, value);
+        assert(!(other_cset_candidates.size() == 2
+                 && eset.contains(other_cset_candidates[1])
+                 && other_eset.contains(other_cset_candidates[0])));
+
         // is this a valid XWing pattern anchored on (cset, eset)?
         if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
 
         // yes! the diagonal corner is the other cset's candidate in the diagonal eset
-        auto other_cset_candidates = candidates(other_cset, value);
         const Cell &diagonal = other_cset_candidates[1];
         assert(other_eset.contains(diagonal));
 

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -27,7 +27,7 @@ namespace {
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const CandidateSet &cset2,
-                                              const EliminationSet &eset1, const EliminationSet &eset2) {
+                                              const EliminationSet &eset1, const EliminationSet &eset2) const {
     // are there exactly two candidates for value in cset1?
     auto candidates1 = candidates(cset1, value);
     if (candidates1.size() != 2) return false;

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -104,9 +104,9 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         // is this a valid XWing pattern anchored on (cset, eset)?
         if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
 
-        // yes! the diagonal corner is the other cset's candidate in the diagonal
-        // eset (test_xwing already verified it lies there)
-        const Cell &diagonal = other_cset_candidates[1];
+        // yes! take the diagonal corner: the other cset's candidate in the
+        // diagonal eset, which test_xwing already verified lies there
+        const Cell diagonal = candidates(other_cset, value)[1];
 
         // record the pattern
         XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -26,56 +26,6 @@ namespace {
 }
 
 template<class CandidateSet, class EliminationSet>
-bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const CandidateSet &cset2,
-                                              const EliminationSet &eset1, const EliminationSet &eset2) const {
-    // are there exactly two candidates for value in cset1?
-    auto candidates1 = candidates(cset1, value);
-    if (candidates1.size() != 2) return false;
-
-    // yes, but are there exactly two candidates for value in cset2?
-    auto candidates2 = candidates(cset2, value);
-    if (candidates2.size() != 2) return false;
-
-    // yes, but is the rectangle actionable -- does either cross line hold more
-    // than its two corners, so there is a third candidate to eliminate? (A lower
-    // bound of two needs no separate check: the containment tests below require
-    // each cross line to hold both its corners, which are distinct cells whenever
-    // cset1 != cset2 -- the only way find_xwing calls this.)
-    auto eliminates1 = candidates(eset1, value);
-    auto eliminates2 = candidates(eset2, value);
-    if (eliminates1.size() <= 2 && eliminates2.size() <= 2) return false;
-
-    // yes -- so the four corners must line up: both base lines' first candidate
-    // in eset1, both their second in eset2. This relies on candidates() yielding
-    // each line's cells in a consistent cross-line order, so index [0] names the
-    // eset1 side and [1] the eset2 side for both base lines. A violation could
-    // only ever cost a false negative (a missed pattern), never a wrong
-    // elimination -- returning true still requires all four real corners. The
-    // production caller find_xwing asserts the order holds for its construction
-    // (the crossed-corner assert at its call site).
-
-    // does eliminates1 contain the first cell in candidates1?
-    if (std::find(eliminates1.begin(), eliminates1.end(), candidates1[0]) == eliminates1.end()) return false;
-
-    // yes, but does eliminates2 contain the second cell in candidates1?
-    if (std::find(eliminates2.begin(), eliminates2.end(), candidates1[1]) == eliminates2.end()) return false;
-
-    // yes, but does eliminates1 contain the first cell in candidates2?
-    if (std::find(eliminates1.begin(), eliminates1.end(), candidates2[0]) == eliminates1.end()) return false;
-
-    // yes, but does eliminates2 contain the second cell in candidates2?
-    if (std::find(eliminates2.begin(), eliminates2.end(), candidates2[1]) == eliminates2.end()) return false;
-
-    return true;
-}
-
-// Explicit instantiations: test_xwing's only in-TU callers are find_xwing, where
-// it is inlined, so without these GCC emits no standalone symbol and the unit
-// test (which calls it across translation units via AnalyzerTest) fails to link.
-template bool Analyzer::test_xwing<Row, Column>(const Value &, const Row &, const Row &, const Column &, const Column &) const;
-template bool Analyzer::test_xwing<Column, Row>(const Value &, const Column &, const Column &, const Row &, const Row &) const;
-
-template<class CandidateSet, class EliminationSet>
 bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset, const std::vector<CandidateSet> &csets, bool by_row) {
     assert(cell.isNote());
     assert(cell.check(value));
@@ -107,24 +57,25 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         // subsequent csets only
         if (!(cset < other_cset)) continue;
 
-        // Invariant: candidates() yields cells in a consistent cross-line order,
-        // so a two-candidate partner can only align with our anchor's corners,
-        // never cross them. test_xwing reports a crossed config as "no" (and we
-        // skip it); assert the impossibility here so a broken ordering invariant
-        // aborts a debug build rather than silently dropping a real pattern.
+        // are there exactly two candidates for this value on this other cset?
         auto other_cset_candidates = candidates(other_cset, value);
-        assert(!(other_cset_candidates.size() == 2
-                 && eset.contains(other_cset_candidates[1])
-                 && other_eset.contains(other_cset_candidates[0])));
+        if (other_cset_candidates.size() != 2) continue;
 
-        // is this a valid XWing pattern anchored on (cset, eset)?
-        if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
+        // yes! does this other cset have candidates in the same esets as our cset
+        assert(!(eset.contains(other_cset_candidates[1]) && other_eset.contains(other_cset_candidates[0])));
+        if (!eset.contains(other_cset_candidates[0])) continue;
+        if (!other_eset.contains(other_cset_candidates[1])) continue;
 
-        // yes! take the diagonal corner: the other cset's candidate in the
-        // diagonal eset, which test_xwing already verified lies there
-        const Cell diagonal = other_cset_candidates[1];
+        // yes! identify the diagonal cell
+        const Cell& diagonal = other_cset_candidates[1];
+        assert(other_eset.contains(diagonal));
 
-        // record the pattern
+        // is this a valid XWing pattern (i.e. other candidates in the same esets would be eliminated)?
+        auto anchor_eliminates = candidates(eset, value);
+        auto diagonal_eliminates = candidates(other_eset, value);
+        if (anchor_eliminates.size() <= 2 && diagonal_eliminates.size() <= 2) continue;
+
+        // yes! record the pattern
         XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};
         assert(mXWings.empty());
         mXWings.push_back(candidate_xwing);

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -25,36 +25,32 @@ namespace {
     }
 }
 
-template<class CandidateSet, class EliminationSet>
-bool Analyzer::test_xwing(const Value &value, const CandidateSet &cset1,   const CandidateSet &cset2,
+// The candidate cells of the two base lines are passed in (the caller has
+// already built them), so this only materialises the cross lines' candidate
+// lists -- and only once the cheap geometric checks have confirmed a rectangle,
+// keeping the common rejection paths allocation-free.
+template<class EliminationSet>
+bool Analyzer::test_xwing(const Value &value, const std::vector<Cell> &candidates1, const std::vector<Cell> &candidates2,
                                               const EliminationSet &eset1, const EliminationSet &eset2) const {
-    // are there exactly two candidates for value in cset1?
-    auto candidates1 = candidates(cset1, value);
+    // are there exactly two candidates for value in each base line?
     if (candidates1.size() != 2) return false;
-
-    // yes, but are there exactly two candidates for value in cset2?
-    auto candidates2 = candidates(cset2, value);
     if (candidates2.size() != 2) return false;
 
-    // yes, but are there at least two candidates in both eset1 and eset2?
+    // yes, but do both base lines place their candidates in the same two cross
+    // lines? The cells are already value-candidates, so geometric membership in a
+    // cross line is equivalent to being one of its value-candidates -- no need to
+    // materialise the cross lines' candidate lists just to test containment.
+    if (!eset1.contains(candidates1[0])) return false;
+    if (!eset2.contains(candidates1[1])) return false;
+    if (!eset1.contains(candidates2[0])) return false;
+    if (!eset2.contains(candidates2[1])) return false;
+
+    // yes, a rectangle -- but is it actionable? The four corners already sit in
+    // the two cross lines, so each holds at least two candidates; at least one
+    // must hold a third for anything to be eliminated.
     auto eliminates1 = candidates(eset1, value);
     auto eliminates2 = candidates(eset2, value);
-    if (eliminates1.size() < 2 || eliminates2.size() < 2) return false;
-
-    // yes, but are there more than two candidates in eset1 or eset 2?
     if (eliminates1.size() <= 2 && eliminates2.size() <= 2) return false;
-
-    // yes, but does eliminates1 contain the first cell in candidates1?
-    if (std::find(eliminates1.begin(), eliminates1.end(), candidates1[0]) == eliminates1.end()) return false;
-
-    // yes, but does eliminates2 contain the second cell in candidates1?
-    if (std::find(eliminates2.begin(), eliminates2.end(), candidates1[1]) == eliminates2.end()) return false;
-
-    // yes, but does eliminates1 contain the first cell in candidates2?
-    if (std::find(eliminates1.begin(), eliminates1.end(), candidates2[0]) == eliminates1.end()) return false;
-
-    // yes, but does eliminates2 contain the second cell in candidates2?
-    if (std::find(eliminates2.begin(), eliminates2.end(), candidates2[1]) == eliminates2.end()) return false;
 
     return true;
 }
@@ -102,11 +98,11 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
                  && other_eset.contains(other_cset_candidates[0])));
 
         // is this a valid XWing pattern anchored on (cset, eset)?
-        if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
+        if (!test_xwing(value, cset_candidates, other_cset_candidates, eset, other_eset)) continue;
 
         // yes! take the diagonal corner: the other cset's candidate in the
         // diagonal eset, which test_xwing already verified lies there
-        const Cell diagonal = candidates(other_cset, value)[1];
+        const Cell diagonal = other_cset_candidates[1];
 
         // record the pattern
         XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -104,9 +104,9 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         // is this a valid XWing pattern anchored on (cset, eset)?
         if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
 
-        // yes! the diagonal corner is the other cset's candidate in the diagonal eset
+        // yes! the diagonal corner is the other cset's candidate in the diagonal
+        // eset (test_xwing already verified it lies there)
         const Cell &diagonal = other_cset_candidates[1];
-        assert(other_eset.contains(diagonal));
 
         // record the pattern
         XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -28,7 +28,7 @@ namespace {
 // The candidate cells of the two base lines are passed in (the caller has
 // already built them), so this only materialises the cross lines' candidate
 // lists -- and only once the cheap geometric checks have confirmed a rectangle,
-// keeping the common rejection paths allocation-free.
+// keeping test_xwing's own rejection paths allocation-free.
 template<class EliminationSet>
 bool Analyzer::test_xwing(const Value &value, const std::vector<Cell> &candidates1, const std::vector<Cell> &candidates2,
                                               const EliminationSet &eset1, const EliminationSet &eset2) const {

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -91,25 +91,15 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         // subsequent csets only
         if (!(cset < other_cset)) continue;
 
-        // are there exactly two candidates for this value on this other cset?
+        // is this a valid XWing pattern anchored on (cset, eset)?
+        if (!test_xwing(value, cset, other_cset, eset, other_eset)) continue;
+
+        // yes! the diagonal corner is the other cset's candidate in the diagonal eset
         auto other_cset_candidates = candidates(other_cset, value);
-        if (other_cset_candidates.size() != 2) continue;
-
-        // yes! does this other cset have candidates in the same esets as our cset
-        assert(!(eset.contains(other_cset_candidates[1]) && other_eset.contains(other_cset_candidates[0])));
-        if (!eset.contains(other_cset_candidates[0])) continue;
-        if (!other_eset.contains(other_cset_candidates[1])) continue;
-
-        // yes! identify the diagonal cell
-        const Cell& diagonal = other_cset_candidates[1];
+        const Cell &diagonal = other_cset_candidates[1];
         assert(other_eset.contains(diagonal));
 
-        // is this a valid XWing pattern (i.e. other candidates in the same esets would be eliminated)?
-        auto anchor_eliminates = candidates(eset, value);
-        auto diagonal_eliminates = candidates(other_eset, value);
-        if (anchor_eliminates.size() <= 2 && diagonal_eliminates.size() <= 2) continue;
-
-        // yes! record the pattern
+        // record the pattern
         XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};
         assert(mXWings.empty());
         mXWings.push_back(candidate_xwing);

--- a/analyzer.h
+++ b/analyzer.h
@@ -169,8 +169,8 @@ private:
     std::vector<XWing> mXWings;
 
     // find
-    template<class CandidateSet, class EliminationSet>
-    bool test_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
+    template<class EliminationSet>
+    bool test_xwing(const Value &value, const std::vector<Cell> &candidates1, const std::vector<Cell> &candidates2,
                                         const EliminationSet &eset1, const EliminationSet &eset2) const;
     template<class CandidateSet, class EliminationSet>
     bool find_xwing(const Cell &, const Value &, const CandidateSet &, const EliminationSet &, const std::vector<CandidateSet> &, bool by_row);

--- a/analyzer.h
+++ b/analyzer.h
@@ -171,7 +171,7 @@ private:
     // find
     template<class CandidateSet, class EliminationSet>
     bool test_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                        const EliminationSet &eset1, const EliminationSet &eset2);
+                                        const EliminationSet &eset1, const EliminationSet &eset2) const;
     template<class CandidateSet, class EliminationSet>
     bool find_xwing(const Cell &, const Value &, const CandidateSet &, const EliminationSet &, const std::vector<CandidateSet> &, bool by_row);
     bool find_xwing(const Cell &, const Value &);

--- a/analyzer.h
+++ b/analyzer.h
@@ -170,9 +170,6 @@ private:
 
     // find
     template<class CandidateSet, class EliminationSet>
-    bool test_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                        const EliminationSet &eset1, const EliminationSet &eset2) const;
-    template<class CandidateSet, class EliminationSet>
     bool find_xwing(const Cell &, const Value &, const CandidateSet &, const EliminationSet &, const std::vector<CandidateSet> &, bool by_row);
     bool find_xwing(const Cell &, const Value &);
     bool find_xwings();

--- a/analyzer.h
+++ b/analyzer.h
@@ -169,8 +169,8 @@ private:
     std::vector<XWing> mXWings;
 
     // find
-    template<class EliminationSet>
-    bool test_xwing(const Value &value, const std::vector<Cell> &candidates1, const std::vector<Cell> &candidates2,
+    template<class CandidateSet, class EliminationSet>
+    bool test_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
                                         const EliminationSet &eset1, const EliminationSet &eset2) const;
     template<class CandidateSet, class EliminationSet>
     bool find_xwing(const Cell &, const Value &, const CandidateSet &, const EliminationSet &, const std::vector<CandidateSet> &, bool by_row);

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -78,20 +78,28 @@ struct AnalyzerTest {
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
     // --- x-wing ---
-    // The rectangle predicate is templated on which lines hold the candidates and
-    // which hold the eliminations; find_xwing instantiates it both ways, so both
-    // are exercised here. r1/r2 and c1/c2 name any cell in each line.
-    //
+    // test_xwing takes the two base lines' candidate cells precomputed (its
+    // callers already have them), so collect them here the same way the analyzer
+    // does. find_xwing instantiates the predicate both ways (elimination sets are
+    // columns, then rows), so both are exercised. r1/r2 and c1/c2 name any cell
+    // in each line.
+    template<class Set>
+    static std::vector<Cell> line_candidates(const Set &set, const Value &v) {
+        std::vector<Cell> out;
+        for (auto const &cell : set)
+            if (cell.isNote() && cell.check(v)) out.push_back(cell);
+        return out;
+    }
     // Row-based: candidate sets are the two rows, elimination sets the columns.
     static bool test_xwing_rows(const Analyzer &a, const Value &v,
                                 const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
-        return a.test_xwing(v, a.mBoard.row(r1), a.mBoard.row(r2),
+        return a.test_xwing(v, line_candidates(a.mBoard.row(r1), v), line_candidates(a.mBoard.row(r2), v),
                                a.mBoard.column(c1), a.mBoard.column(c2));
     }
     // Column-based: candidate sets are the two columns, elimination sets the rows.
     static bool test_xwing_cols(const Analyzer &a, const Value &v,
                                 const Cell &c1, const Cell &c2, const Cell &r1, const Cell &r2) {
-        return a.test_xwing(v, a.mBoard.column(c1), a.mBoard.column(c2),
+        return a.test_xwing(v, line_candidates(a.mBoard.column(c1), v), line_candidates(a.mBoard.column(c2), v),
                                a.mBoard.row(r1), a.mBoard.row(r2));
     }
 

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -78,28 +78,20 @@ struct AnalyzerTest {
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
     // --- x-wing ---
-    // test_xwing takes the two base lines' candidate cells precomputed (its
-    // callers already have them), so collect them here the same way the analyzer
-    // does. find_xwing instantiates the predicate both ways (elimination sets are
-    // columns, then rows), so both are exercised. r1/r2 and c1/c2 name any cell
-    // in each line.
-    template<class Set>
-    static std::vector<Cell> line_candidates(const Set &set, const Value &v) {
-        std::vector<Cell> out;
-        for (auto const &cell : set)
-            if (cell.isNote() && cell.check(v)) out.push_back(cell);
-        return out;
-    }
+    // test_xwing is a set predicate -- it extracts the candidates itself -- so
+    // pass the lines directly. find_xwing instantiates it both ways (elimination
+    // sets are columns, then rows), so both are exercised. r1/r2 and c1/c2 name
+    // any cell in each line.
     // Row-based: candidate sets are the two rows, elimination sets the columns.
     static bool test_xwing_rows(const Analyzer &a, const Value &v,
                                 const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
-        return a.test_xwing(v, line_candidates(a.mBoard.row(r1), v), line_candidates(a.mBoard.row(r2), v),
+        return a.test_xwing(v, a.mBoard.row(r1), a.mBoard.row(r2),
                                a.mBoard.column(c1), a.mBoard.column(c2));
     }
     // Column-based: candidate sets are the two columns, elimination sets the rows.
     static bool test_xwing_cols(const Analyzer &a, const Value &v,
                                 const Cell &c1, const Cell &c2, const Cell &r1, const Cell &r2) {
-        return a.test_xwing(v, line_candidates(a.mBoard.column(c1), v), line_candidates(a.mBoard.column(c2), v),
+        return a.test_xwing(v, a.mBoard.column(c1), a.mBoard.column(c2),
                                a.mBoard.row(r1), a.mBoard.row(r2));
     }
 

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -77,6 +77,16 @@ struct AnalyzerTest {
     static size_t ywing_count(const Analyzer &a)                                                   { return a.mYWings.size(); }
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
+    // --- x-wing ---
+    // Row-based instantiation of the rectangle predicate: the candidate sets are
+    // the two rows, the elimination sets the two columns. r1/r2 name any cell in
+    // each candidate row; c1/c2 name any cell in each elimination column.
+    static bool test_xwing(const Analyzer &a, const Value &v,
+                           const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
+        return a.test_xwing(v, a.mBoard.row(r1), a.mBoard.row(r2),
+                               a.mBoard.column(c1), a.mBoard.column(c2));
+    }
+
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
     static bool act_on_color_chain(Analyzer &a)                                     { return a.act_on_color_chain(); }
@@ -297,6 +307,67 @@ void test_ywing_rejects_non_patterns() {
 }
 
 // ===========================================================================
+// X-Wing
+// ===========================================================================
+
+// test_xwing is the rectangle predicate find_xwing relies on. The black-box
+// suite only ever drives it down one happy-path board, so its rejection
+// branches -- candidate row not exactly two, corners not aligned in the same
+// columns, and no third candidate to eliminate -- go unverified there. One
+// distribution of value 7 supplies a real X-Wing plus three near-misses:
+//
+//        c1 c2 c3 c4 c5 c6 c7 c8
+//   r0    7              7              <- top of the real X-Wing (cols 1,5)
+//   r2    7                       7     <- misaligned: shares c1, not c5
+//   r3    7              7              <- bottom of the real X-Wing (cols 1,5)
+//   r4       7        7  7              <- three 7s: too many to anchor (cols 2,6,7)
+//   r6    7                             <- stray in c1: what the real X-Wing clears
+//   r7          7  7                    <- aligned pair on cols 3,4 ...
+//   r8          7  7                    <- ... but c3/c4 hold nothing else to clear
+void test_xwing_detect_and_reject() {
+    std::cout << "[x-wing] the rectangle predicate accepts a real X-Wing and rejects near-misses\n";
+    Board board = empty_board();
+    const Value V = kSeven;
+    confine_value(board, V, {
+        {0,1},{0,5},        // row 0   real X-Wing top
+        {3,1},{3,5},        // row 3   real X-Wing bottom (aligned on cols 1,5)
+        {6,1},              // row 6   stray in col 1 -> the eliminable candidate
+        {2,1},{2,8},        // row 2   misaligned partner (col 8, not col 5)
+        {4,2},{4,6},{4,7},  // row 4   three candidates -> cannot anchor
+        {7,3},{7,4},        // row 7   aligned pair on cols 3,4 ...
+        {8,3},{8,4},        // row 8   ... with no stray in either column
+    });
+
+    Analyzer analyzer(board);
+
+    // Positive control: rows 0 and 3 share columns 1 and 5, and column 1 carries
+    // the row-6 stray, so the rectangle is real and actionable.
+    check(AnalyzerTest::test_xwing(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 3, 0),    // candidate rows 0, 3
+              cell_at(board, 0, 1), cell_at(board, 0, 5)),   // elimination cols 1, 5
+          "accepted: aligned rows with a third candidate to eliminate");
+
+    // Reject: row 2's second 7 is in column 8, so the fourth corner is absent.
+    check(!AnalyzerTest::test_xwing(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 2, 0),
+              cell_at(board, 0, 1), cell_at(board, 0, 5)),
+          "rejected: the two rows' candidates lie in different columns");
+
+    // Reject: row 4 holds three 7s, so it cannot be a base of the rectangle.
+    check(!AnalyzerTest::test_xwing(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 4, 0),
+              cell_at(board, 0, 1), cell_at(board, 0, 5)),
+          "rejected: a candidate row has three candidates, not two");
+
+    // Reject: rows 7 and 8 align perfectly on columns 3 and 4, but neither
+    // column carries a third 7, so there is nothing to eliminate.
+    check(!AnalyzerTest::test_xwing(analyzer, V,
+              cell_at(board, 7, 0), cell_at(board, 8, 0),
+              cell_at(board, 0, 3), cell_at(board, 0, 4)),
+          "rejected: a perfect rectangle with no third candidate to eliminate");
+}
+
+// ===========================================================================
 // Simple coloring
 // ===========================================================================
 
@@ -355,6 +426,7 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
+    test_xwing_detect_and_reject();
     test_colorchain_rule2_contradiction();
     test_colorchain_benign_not_actionable();
 

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -78,22 +78,13 @@ struct AnalyzerTest {
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
     // --- x-wing ---
-    // test_xwing is a set predicate -- it extracts the candidates itself -- so
-    // pass the lines directly. find_xwing instantiates it both ways (elimination
-    // sets are columns, then rows), so both are exercised. r1/r2 and c1/c2 name
-    // any cell in each line.
-    // Row-based: candidate sets are the two rows, elimination sets the columns.
-    static bool test_xwing_rows(const Analyzer &a, const Value &v,
-                                const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
-        return a.test_xwing(v, a.mBoard.row(r1), a.mBoard.row(r2),
-                               a.mBoard.column(c1), a.mBoard.column(c2));
-    }
-    // Column-based: candidate sets are the two columns, elimination sets the rows.
-    static bool test_xwing_cols(const Analyzer &a, const Value &v,
-                                const Cell &c1, const Cell &c2, const Cell &r1, const Cell &r2) {
-        return a.test_xwing(v, a.mBoard.column(c1), a.mBoard.column(c2),
-                               a.mBoard.row(r1), a.mBoard.row(r2));
-    }
+    // find_xwing validates inline (like find_swordfish), so drive it on crafted
+    // boards through its anchor entry point and inspect the recorded result.
+    static bool   find_xwing(Analyzer &a, const Cell &c, const Value &v) { return a.find_xwing(c, v); }
+    static bool   act_on_xwing(Analyzer &a)                              { return a.act_on_xwing(); }
+    static size_t xwing_count(const Analyzer &a)                         { return a.mXWings.size(); }
+    static bool   xwing_row_based(const Analyzer &a)                     { return a.mXWings.at(0).is_row_based; }
+    static Value  xwing_value(const Analyzer &a)                         { return a.mXWings.at(0).value; }
 
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
@@ -318,128 +309,107 @@ void test_ywing_rejects_non_patterns() {
 // X-Wing
 // ===========================================================================
 
-// test_xwing is the rectangle predicate find_xwing relies on. The black-box
-// suite only ever drives it down one happy-path board, so its rejection
-// branches -- candidate line not exactly two, corners not aligned in the same
-// cross-lines, and no third candidate to eliminate -- go unverified there.
-//
-// find_xwing instantiates the predicate two ways (rows-hold-candidates and
-// columns-hold-candidates), so both are tested below on transposed boards.
+// find_xwing validates inline. The black-box suite drives it on real solves;
+// these whitebox cases craft small boards and drive find_xwing through its
+// anchor entry point -- the same way the Swordfish tests drive find_swordfish --
+// to cover both orientations and the rejection paths a happy-path solve does not
+// isolate.
 
-// Row-based: one distribution of value 7 supplies a real X-Wing plus three
-// near-misses:
+// A row-based X-Wing on value 7: rows 0 and 3 each hold 7 in exactly columns 1
+// and 5. Columns 1 and 5 carry one extra 7 apiece (rows 6 and 7), so the pattern
+// is actionable and those strays are eliminated.
 //
-//        c1 c2 c3 c4 c5 c6 c7 c8
-//   r0    7              7              <- top of the real X-Wing (cols 1,5)
-//   r2    7                       7     <- misaligned: shares c1, not c5 (also a c1 stray)
-//   r3    7              7              <- bottom of the real X-Wing (cols 1,5)
-//   r4       7        7  7              <- three 7s: too many to anchor (cols 2,6,7)
-//   r6    7                             <- a second c1 stray; the X-Wing clears r2 and r6
-//   r7          7  7                    <- aligned pair on cols 3,4 ...
-//   r8          7  7                    <- ... but c3/c4 hold nothing else to clear
-void test_xwing_rows_detect_and_reject() {
-    std::cout << "[x-wing] row-based: the predicate accepts a real X-Wing and rejects near-misses\n";
+//        c1 c5
+//   r0    7  7      <- top corners
+//   r3    7  7      <- bottom corners
+//   r6    7         <- stray cleared from column 1
+//   r7       7      <- stray cleared from column 5
+void test_xwing_row_based() {
+    std::cout << "[x-wing] row-based detection, action\n";
     Board board = empty_board();
     const Value V = kSeven;
-    confine_value(board, V, {
-        {0,1},{0,5},        // row 0   real X-Wing top
-        {3,1},{3,5},        // row 3   real X-Wing bottom (aligned on cols 1,5)
-        {6,1},              // row 6   stray in col 1 -> an eliminable candidate
-        {2,1},{2,8},        // row 2   misaligned partner (col 8, not col 5); (2,1) is a second col-1 stray
-        {4,2},{4,6},{4,7},  // row 4   three candidates -> cannot anchor
-        {7,3},{7,4},        // row 7   aligned pair on cols 3,4 ...
-        {8,3},{8,4},        // row 8   ... with no stray in either column
-    });
+    confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
     Analyzer analyzer(board);
+    // Anchor on (0,1), the first 7 of row 0 -- find_xwing's top-left corner.
+    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
+    check(found, "row X-Wing detected with anchor (0,1)");
+    check(AnalyzerTest::xwing_count(analyzer) == 1, "exactly one X-Wing recorded");
+    if (AnalyzerTest::xwing_count(analyzer) == 1) {
+        check(AnalyzerTest::xwing_row_based(analyzer), "recorded X-Wing is row-based");
+        check(AnalyzerTest::xwing_value(analyzer) == V, "recorded X-Wing is for value 7");
+    }
 
-    // Positive control: rows 0 and 3 share columns 1 and 5, and column 1 carries
-    // two further candidates outside the rectangle (rows 2 and 6), so it is real
-    // and actionable -- both would be eliminated.
-    check(AnalyzerTest::test_xwing_rows(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 3, 0),    // candidate rows 0, 3
-              cell_at(board, 0, 1), cell_at(board, 0, 5)),   // elimination cols 1, 5
-          "accepted: aligned rows with a third candidate to eliminate");
-
-    // Reject: row 2's second 7 is in column 8, so the fourth corner is absent.
-    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 2, 0),
-              cell_at(board, 0, 1), cell_at(board, 0, 5)),
-          "rejected: the two rows' candidates lie in different columns");
-
-    // Reject: row 4 holds three 7s, so it cannot be a base of the rectangle.
-    // Pass it in the FIRST candidate slot so this exercises the candidates1 size
-    // guard; the column test below keeps its three-candidate line second, so the
-    // two guards are each covered once.
-    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
-              cell_at(board, 4, 0), cell_at(board, 0, 0),   // three-candidate row first
-              cell_at(board, 0, 1), cell_at(board, 0, 5)),
-          "rejected: a candidate row has three candidates, not two");
-
-    // Reject: rows 7 and 8 align perfectly on columns 3 and 4, but neither
-    // column carries a third 7, so there is nothing to eliminate.
-    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
-              cell_at(board, 7, 0), cell_at(board, 8, 0),
-              cell_at(board, 0, 3), cell_at(board, 0, 4)),
-          "rejected: a perfect rectangle with no third candidate to eliminate");
+    bool acted = AnalyzerTest::act_on_xwing(analyzer);
+    check(acted, "act_on_xwing reports an elimination");
+    check(!has_candidate(board, 6, 1, V), "stray 7 at (6,1) eliminated from column 1");
+    check(!has_candidate(board, 7, 5, V), "stray 7 at (7,5) eliminated from column 5");
+    check(has_candidate(board, 0, 1, V) && has_candidate(board, 0, 5, V)
+       && has_candidate(board, 3, 1, V) && has_candidate(board, 3, 5, V),
+          "all four corner cells kept candidate 7");
 }
 
-// Column-based: the transpose of the row-based board, so the candidate sets are
-// columns and the elimination sets are rows. Same four cases, mirrored:
+// The transpose: a column-based X-Wing on value 7. Columns 0 and 3 each hold 7
+// in exactly rows 1 and 5; rows 1 and 5 carry one extra 7 apiece to eliminate.
+// Anchoring on (1,0) makes the row search bail (row 1 has three 7s) before the
+// column search succeeds, so this exercises the column orientation.
 //
-//        c0 c2 c3 c4 c6 c7 c8
-//   r1    7  7  7     7              <- real X-Wing top (cols 0,3); c2 and c6 are strays it clears
-//   r2             7                 <- col 4: one of three 7s -> cannot anchor
-//   r3                   7  7        <- aligned pair on cols 7,8 ...
-//   r4                   7  7        <- ... but rows 3,4 hold nothing else to clear
-//   r5    7     7                    <- bottom of the real X-Wing (cols 0,3)
-//   r6             7                 <- col 4: second of three 7s
-//   r7             7                 <- col 4: third of three 7s
-//   r8       7                       <- misaligned: shares r1's col 2, not col 3 (its (1,2) is the second r1 stray)
-void test_xwing_cols_detect_and_reject() {
-    std::cout << "[x-wing] column-based: the predicate accepts a real X-Wing and rejects near-misses\n";
+//        c0 c3 c6 c7
+//   r1    7  7  7        <- left/right corners; c6 stray cleared from row 1
+//   r5    7  7     7     <- left/right corners; c7 stray cleared from row 5
+void test_xwing_column_based() {
+    std::cout << "[x-wing] column-based detection, action\n";
     Board board = empty_board();
     const Value V = kSeven;
-    confine_value(board, V, {
-        {1,0},{5,0},        // col 0   real X-Wing left
-        {1,3},{5,3},        // col 3   real X-Wing right (aligned on rows 1,5)
-        {1,6},              // col 6   stray in row 1 -> an eliminable candidate
-        {1,2},{8,2},        // col 2   misaligned partner (row 8, not row 5); (1,2) is a second row-1 stray
-        {2,4},{6,4},{7,4},  // col 4   three candidates -> cannot anchor
-        {3,7},{4,7},        // col 7   aligned pair on rows 3,4 ...
-        {3,8},{4,8},        // col 8   ... with no stray in either row
-    });
+    confine_value(board, V, { {1,0},{5,0}, {1,3},{5,3}, {1,6}, {5,7} });
 
     Analyzer analyzer(board);
+    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 1, 0), V);
+    check(found, "column X-Wing detected with anchor (1,0)");
+    check(AnalyzerTest::xwing_count(analyzer) == 1, "exactly one X-Wing recorded");
+    if (AnalyzerTest::xwing_count(analyzer) == 1) {
+        check(!AnalyzerTest::xwing_row_based(analyzer), "recorded X-Wing is column-based");
+        check(AnalyzerTest::xwing_value(analyzer) == V, "recorded X-Wing is for value 7");
+    }
 
-    // Positive control: columns 0 and 3 share rows 1 and 5, and row 1 carries
-    // two further candidates outside the rectangle (cols 2 and 6), so it is real
-    // and actionable -- both would be eliminated.
-    check(AnalyzerTest::test_xwing_cols(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 0, 3),    // candidate cols 0, 3
-              cell_at(board, 1, 0), cell_at(board, 5, 0)),   // elimination rows 1, 5
-          "accepted: aligned columns with a third candidate to eliminate");
+    bool acted = AnalyzerTest::act_on_xwing(analyzer);
+    check(acted, "act_on_xwing reports an elimination");
+    check(!has_candidate(board, 1, 6, V), "stray 7 at (1,6) eliminated from row 1");
+    check(!has_candidate(board, 5, 7, V), "stray 7 at (5,7) eliminated from row 5");
+    check(has_candidate(board, 1, 0, V) && has_candidate(board, 5, 0, V)
+       && has_candidate(board, 1, 3, V) && has_candidate(board, 5, 3, V),
+          "all four corner cells kept candidate 7");
+}
 
-    // Reject: col 2's second 7 is in row 8, so the fourth corner is absent.
-    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 0, 2),
-              cell_at(board, 1, 0), cell_at(board, 5, 0)),
-          "rejected: the two columns' candidates lie in different rows");
+// A perfect rectangle with nothing to eliminate must not be recorded (recording
+// it would assert in act). Rows 0 and 3 hold 7 in columns 1 and 5 and nowhere
+// else, so neither column carries a third candidate.
+void test_xwing_no_elimination() {
+    std::cout << "[x-wing] a rectangle with nothing to eliminate is not recorded\n";
+    Board board = empty_board();
+    const Value V = kSeven;
+    confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5} });
 
-    // Reject: col 4 holds three 7s, so it cannot be a base of the rectangle.
-    // Kept in the SECOND candidate slot, exercising the candidates2 size guard
-    // (the row test above covers candidates1).
-    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 0, 4),
-              cell_at(board, 1, 0), cell_at(board, 5, 0)),
-          "rejected: a candidate column has three candidates, not two");
+    Analyzer analyzer(board);
+    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
+    check(!found, "no X-Wing reported when there is nothing to eliminate");
+    check(AnalyzerTest::xwing_count(analyzer) == 0, "no X-Wing recorded");
+}
 
-    // Reject: cols 7 and 8 align perfectly on rows 3 and 4, but neither row
-    // carries a third 7, so there is nothing to eliminate.
-    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
-              cell_at(board, 0, 7), cell_at(board, 0, 8),
-              cell_at(board, 3, 0), cell_at(board, 4, 0)),
-          "rejected: a perfect rectangle with no third candidate to eliminate");
+// A near-miss: the two candidate rows do not share both columns, so no rectangle
+// forms. Row 0 holds 7 in columns 1 and 5; row 3 in columns 1 and 8 -- they
+// share column 1 only, so the fourth corner is absent and find_xwing reports
+// nothing from either orientation.
+void test_xwing_misaligned_not_found() {
+    std::cout << "[x-wing] misaligned candidate lines yield no pattern\n";
+    Board board = empty_board();
+    const Value V = kSeven;
+    confine_value(board, V, { {0,1},{0,5}, {3,1},{3,8}, {7,5} });
+
+    Analyzer analyzer(board);
+    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
+    check(!found, "no X-Wing reported when the candidate lines are misaligned");
+    check(AnalyzerTest::xwing_count(analyzer) == 0, "no X-Wing recorded");
 }
 
 // ===========================================================================
@@ -501,8 +471,10 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
-    test_xwing_rows_detect_and_reject();
-    test_xwing_cols_detect_and_reject();
+    test_xwing_row_based();
+    test_xwing_column_based();
+    test_xwing_no_elimination();
+    test_xwing_misaligned_not_found();
     test_colorchain_rule2_contradiction();
     test_colorchain_benign_not_actionable();
 

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -339,10 +339,10 @@ void test_ywing_rejects_non_patterns() {
 //
 //        c1 c2 c3 c4 c5 c6 c7 c8
 //   r0    7              7              <- top of the real X-Wing (cols 1,5)
-//   r2    7                       7     <- misaligned: shares c1, not c5
+//   r2    7                       7     <- misaligned: shares c1, not c5 (also a c1 stray)
 //   r3    7              7              <- bottom of the real X-Wing (cols 1,5)
 //   r4       7        7  7              <- three 7s: too many to anchor (cols 2,6,7)
-//   r6    7                             <- stray in c1: what the real X-Wing clears
+//   r6    7                             <- a second c1 stray; the X-Wing clears r2 and r6
 //   r7          7  7                    <- aligned pair on cols 3,4 ...
 //   r8          7  7                    <- ... but c3/c4 hold nothing else to clear
 void test_xwing_rows_detect_and_reject() {
@@ -352,8 +352,8 @@ void test_xwing_rows_detect_and_reject() {
     confine_value(board, V, {
         {0,1},{0,5},        // row 0   real X-Wing top
         {3,1},{3,5},        // row 3   real X-Wing bottom (aligned on cols 1,5)
-        {6,1},              // row 6   stray in col 1 -> the eliminable candidate
-        {2,1},{2,8},        // row 2   misaligned partner (col 8, not col 5)
+        {6,1},              // row 6   stray in col 1 -> an eliminable candidate
+        {2,1},{2,8},        // row 2   misaligned partner (col 8, not col 5); (2,1) is a second col-1 stray
         {4,2},{4,6},{4,7},  // row 4   three candidates -> cannot anchor
         {7,3},{7,4},        // row 7   aligned pair on cols 3,4 ...
         {8,3},{8,4},        // row 8   ... with no stray in either column
@@ -362,7 +362,8 @@ void test_xwing_rows_detect_and_reject() {
     Analyzer analyzer(board);
 
     // Positive control: rows 0 and 3 share columns 1 and 5, and column 1 carries
-    // the row-6 stray, so the rectangle is real and actionable.
+    // two further candidates outside the rectangle (rows 2 and 6), so it is real
+    // and actionable -- both would be eliminated.
     check(AnalyzerTest::test_xwing_rows(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 3, 0),    // candidate rows 0, 3
               cell_at(board, 0, 1), cell_at(board, 0, 5)),   // elimination cols 1, 5

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -375,8 +375,11 @@ void test_xwing_rows_detect_and_reject() {
           "rejected: the two rows' candidates lie in different columns");
 
     // Reject: row 4 holds three 7s, so it cannot be a base of the rectangle.
+    // Pass it in the FIRST candidate slot so this exercises the candidates1 size
+    // guard; the column test below keeps its three-candidate line second, so the
+    // two guards are each covered once.
     check(!AnalyzerTest::test_xwing_rows(analyzer, V,
-              cell_at(board, 0, 0), cell_at(board, 4, 0),
+              cell_at(board, 4, 0), cell_at(board, 0, 0),   // three-candidate row first
               cell_at(board, 0, 1), cell_at(board, 0, 5)),
           "rejected: a candidate row has three candidates, not two");
 
@@ -430,6 +433,8 @@ void test_xwing_cols_detect_and_reject() {
           "rejected: the two columns' candidates lie in different rows");
 
     // Reject: col 4 holds three 7s, so it cannot be a base of the rectangle.
+    // Kept in the SECOND candidate slot, exercising the candidates2 size guard
+    // (the row test above covers candidates1).
     check(!AnalyzerTest::test_xwing_cols(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 0, 4),
               cell_at(board, 1, 0), cell_at(board, 5, 0)),

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -78,13 +78,21 @@ struct AnalyzerTest {
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
     // --- x-wing ---
-    // Row-based instantiation of the rectangle predicate: the candidate sets are
-    // the two rows, the elimination sets the two columns. r1/r2 name any cell in
-    // each candidate row; c1/c2 name any cell in each elimination column.
-    static bool test_xwing(const Analyzer &a, const Value &v,
-                           const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
+    // The rectangle predicate is templated on which lines hold the candidates and
+    // which hold the eliminations; find_xwing instantiates it both ways, so both
+    // are exercised here. r1/r2 and c1/c2 name any cell in each line.
+    //
+    // Row-based: candidate sets are the two rows, elimination sets the columns.
+    static bool test_xwing_rows(const Analyzer &a, const Value &v,
+                                const Cell &r1, const Cell &r2, const Cell &c1, const Cell &c2) {
         return a.test_xwing(v, a.mBoard.row(r1), a.mBoard.row(r2),
                                a.mBoard.column(c1), a.mBoard.column(c2));
+    }
+    // Column-based: candidate sets are the two columns, elimination sets the rows.
+    static bool test_xwing_cols(const Analyzer &a, const Value &v,
+                                const Cell &c1, const Cell &c2, const Cell &r1, const Cell &r2) {
+        return a.test_xwing(v, a.mBoard.column(c1), a.mBoard.column(c2),
+                               a.mBoard.row(r1), a.mBoard.row(r2));
     }
 
     // --- simple coloring ---
@@ -312,9 +320,14 @@ void test_ywing_rejects_non_patterns() {
 
 // test_xwing is the rectangle predicate find_xwing relies on. The black-box
 // suite only ever drives it down one happy-path board, so its rejection
-// branches -- candidate row not exactly two, corners not aligned in the same
-// columns, and no third candidate to eliminate -- go unverified there. One
-// distribution of value 7 supplies a real X-Wing plus three near-misses:
+// branches -- candidate line not exactly two, corners not aligned in the same
+// cross-lines, and no third candidate to eliminate -- go unverified there.
+//
+// find_xwing instantiates the predicate two ways (rows-hold-candidates and
+// columns-hold-candidates), so both are tested below on transposed boards.
+
+// Row-based: one distribution of value 7 supplies a real X-Wing plus three
+// near-misses:
 //
 //        c1 c2 c3 c4 c5 c6 c7 c8
 //   r0    7              7              <- top of the real X-Wing (cols 1,5)
@@ -324,8 +337,8 @@ void test_ywing_rejects_non_patterns() {
 //   r6    7                             <- stray in c1: what the real X-Wing clears
 //   r7          7  7                    <- aligned pair on cols 3,4 ...
 //   r8          7  7                    <- ... but c3/c4 hold nothing else to clear
-void test_xwing_detect_and_reject() {
-    std::cout << "[x-wing] the rectangle predicate accepts a real X-Wing and rejects near-misses\n";
+void test_xwing_rows_detect_and_reject() {
+    std::cout << "[x-wing] row-based: the predicate accepts a real X-Wing and rejects near-misses\n";
     Board board = empty_board();
     const Value V = kSeven;
     confine_value(board, V, {
@@ -342,28 +355,83 @@ void test_xwing_detect_and_reject() {
 
     // Positive control: rows 0 and 3 share columns 1 and 5, and column 1 carries
     // the row-6 stray, so the rectangle is real and actionable.
-    check(AnalyzerTest::test_xwing(analyzer, V,
+    check(AnalyzerTest::test_xwing_rows(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 3, 0),    // candidate rows 0, 3
               cell_at(board, 0, 1), cell_at(board, 0, 5)),   // elimination cols 1, 5
           "accepted: aligned rows with a third candidate to eliminate");
 
     // Reject: row 2's second 7 is in column 8, so the fourth corner is absent.
-    check(!AnalyzerTest::test_xwing(analyzer, V,
+    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 2, 0),
               cell_at(board, 0, 1), cell_at(board, 0, 5)),
           "rejected: the two rows' candidates lie in different columns");
 
     // Reject: row 4 holds three 7s, so it cannot be a base of the rectangle.
-    check(!AnalyzerTest::test_xwing(analyzer, V,
+    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 4, 0),
               cell_at(board, 0, 1), cell_at(board, 0, 5)),
           "rejected: a candidate row has three candidates, not two");
 
     // Reject: rows 7 and 8 align perfectly on columns 3 and 4, but neither
     // column carries a third 7, so there is nothing to eliminate.
-    check(!AnalyzerTest::test_xwing(analyzer, V,
+    check(!AnalyzerTest::test_xwing_rows(analyzer, V,
               cell_at(board, 7, 0), cell_at(board, 8, 0),
               cell_at(board, 0, 3), cell_at(board, 0, 4)),
+          "rejected: a perfect rectangle with no third candidate to eliminate");
+}
+
+// Column-based: the transpose of the row-based board, so the candidate sets are
+// columns and the elimination sets are rows. Same four cases, mirrored:
+//
+//        c0 c2 c3 c4 c6 c7 c8
+//   r1    7  7  7     7              <- top of the real X-Wing (cols 0,3); c6 stray
+//   r2             7                 <- col 4: one of three 7s -> cannot anchor
+//   r3                   7  7        <- aligned pair on cols 7,8 ...
+//   r4                   7  7        <- ... but rows 3,4 hold nothing else to clear
+//   r5    7     7                    <- bottom of the real X-Wing (cols 0,3)
+//   r6             7                 <- col 4: second of three 7s
+//   r7             7                 <- col 4: third of three 7s
+//   r8       7                       <- misaligned: shares r1's col 2, not col 3
+void test_xwing_cols_detect_and_reject() {
+    std::cout << "[x-wing] column-based: the predicate accepts a real X-Wing and rejects near-misses\n";
+    Board board = empty_board();
+    const Value V = kSeven;
+    confine_value(board, V, {
+        {1,0},{5,0},        // col 0   real X-Wing left
+        {1,3},{5,3},        // col 3   real X-Wing right (aligned on rows 1,5)
+        {1,6},              // col 6   stray in row 1 -> the eliminable candidate
+        {1,2},{8,2},        // col 2   misaligned partner (row 8, not row 5)
+        {2,4},{6,4},{7,4},  // col 4   three candidates -> cannot anchor
+        {3,7},{4,7},        // col 7   aligned pair on rows 3,4 ...
+        {3,8},{4,8},        // col 8   ... with no stray in either row
+    });
+
+    Analyzer analyzer(board);
+
+    // Positive control: columns 0 and 3 share rows 1 and 5, and row 1 carries
+    // the col-6 stray, so the rectangle is real and actionable.
+    check(AnalyzerTest::test_xwing_cols(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 0, 3),    // candidate cols 0, 3
+              cell_at(board, 1, 0), cell_at(board, 5, 0)),   // elimination rows 1, 5
+          "accepted: aligned columns with a third candidate to eliminate");
+
+    // Reject: col 2's second 7 is in row 8, so the fourth corner is absent.
+    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 0, 2),
+              cell_at(board, 1, 0), cell_at(board, 5, 0)),
+          "rejected: the two columns' candidates lie in different rows");
+
+    // Reject: col 4 holds three 7s, so it cannot be a base of the rectangle.
+    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
+              cell_at(board, 0, 0), cell_at(board, 0, 4),
+              cell_at(board, 1, 0), cell_at(board, 5, 0)),
+          "rejected: a candidate column has three candidates, not two");
+
+    // Reject: cols 7 and 8 align perfectly on rows 3 and 4, but neither row
+    // carries a third 7, so there is nothing to eliminate.
+    check(!AnalyzerTest::test_xwing_cols(analyzer, V,
+              cell_at(board, 0, 7), cell_at(board, 0, 8),
+              cell_at(board, 3, 0), cell_at(board, 4, 0)),
           "rejected: a perfect rectangle with no third candidate to eliminate");
 }
 
@@ -426,7 +494,8 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
-    test_xwing_detect_and_reject();
+    test_xwing_rows_detect_and_reject();
+    test_xwing_cols_detect_and_reject();
     test_colorchain_rule2_contradiction();
     test_colorchain_benign_not_actionable();
 

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -388,14 +388,14 @@ void test_xwing_rows_detect_and_reject() {
 // columns and the elimination sets are rows. Same four cases, mirrored:
 //
 //        c0 c2 c3 c4 c6 c7 c8
-//   r1    7  7  7     7              <- top of the real X-Wing (cols 0,3); c6 stray
+//   r1    7  7  7     7              <- real X-Wing top (cols 0,3); c2 and c6 are strays it clears
 //   r2             7                 <- col 4: one of three 7s -> cannot anchor
 //   r3                   7  7        <- aligned pair on cols 7,8 ...
 //   r4                   7  7        <- ... but rows 3,4 hold nothing else to clear
 //   r5    7     7                    <- bottom of the real X-Wing (cols 0,3)
 //   r6             7                 <- col 4: second of three 7s
 //   r7             7                 <- col 4: third of three 7s
-//   r8       7                       <- misaligned: shares r1's col 2, not col 3
+//   r8       7                       <- misaligned: shares r1's col 2, not col 3 (its (1,2) is the second r1 stray)
 void test_xwing_cols_detect_and_reject() {
     std::cout << "[x-wing] column-based: the predicate accepts a real X-Wing and rejects near-misses\n";
     Board board = empty_board();
@@ -403,8 +403,8 @@ void test_xwing_cols_detect_and_reject() {
     confine_value(board, V, {
         {1,0},{5,0},        // col 0   real X-Wing left
         {1,3},{5,3},        // col 3   real X-Wing right (aligned on rows 1,5)
-        {1,6},              // col 6   stray in row 1 -> the eliminable candidate
-        {1,2},{8,2},        // col 2   misaligned partner (row 8, not row 5)
+        {1,6},              // col 6   stray in row 1 -> an eliminable candidate
+        {1,2},{8,2},        // col 2   misaligned partner (row 8, not row 5); (1,2) is a second row-1 stray
         {2,4},{6,4},{7,4},  // col 4   three candidates -> cannot anchor
         {3,7},{4,7},        // col 7   aligned pair on rows 3,4 ...
         {3,8},{4,8},        // col 8   ... with no stray in either row
@@ -413,7 +413,8 @@ void test_xwing_cols_detect_and_reject() {
     Analyzer analyzer(board);
 
     // Positive control: columns 0 and 3 share rows 1 and 5, and row 1 carries
-    // the col-6 stray, so the rectangle is real and actionable.
+    // two further candidates outside the rectangle (cols 2 and 6), so it is real
+    // and actionable -- both would be eliminated.
     check(AnalyzerTest::test_xwing_cols(analyzer, V,
               cell_at(board, 0, 0), cell_at(board, 0, 3),    // candidate cols 0, 3
               cell_at(board, 1, 0), cell_at(board, 5, 0)),   // elimination rows 1, 5

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -396,20 +396,52 @@ void test_xwing_no_elimination() {
     check(AnalyzerTest::xwing_count(analyzer) == 0, "no X-Wing recorded");
 }
 
-// A near-miss: the two candidate rows do not share both columns, so no rectangle
-// forms. Row 0 holds 7 in columns 1 and 5; row 3 in columns 1 and 8 -- they
-// share column 1 only, so the fourth corner is absent and find_xwing reports
-// nothing from either orientation.
+// Near-misses: the partner row shares only one of the anchor's two columns, so
+// the fourth corner is absent. find_xwing has two containment checks -- one per
+// corner of the partner -- and which rejects depends on which column is the odd
+// one out, so cover both.
 void test_xwing_misaligned_not_found() {
     std::cout << "[x-wing] misaligned candidate lines yield no pattern\n";
+    const Value V = kSeven;
+
+    // Partner's SECOND candidate is off the rectangle: row 0 in cols 1,5; row 3
+    // in cols 1,8 -- shares col 1, misses col 5 (rejected at the other_eset check).
+    {
+        Board board = empty_board();
+        confine_value(board, V, { {0,1},{0,5}, {3,1},{3,8}, {7,5} });
+        Analyzer analyzer(board);
+        check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V),
+              "no X-Wing when the partner's second candidate is off the rectangle");
+        check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded");
+    }
+
+    // Partner's FIRST candidate is off the rectangle: row 0 in cols 1,5; row 3 in
+    // cols 2,5 -- shares col 5, misses col 1 (rejected at the eset check).
+    {
+        Board board = empty_board();
+        confine_value(board, V, { {0,1},{0,5}, {3,2},{3,5} });
+        Analyzer analyzer(board);
+        check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V),
+              "no X-Wing when the partner's first candidate is off the rectangle");
+        check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded");
+    }
+}
+
+// find_xwing canonicalises on the first candidate of the anchor's line: anchored
+// on a line's *second* candidate it bails at once (a row X-Wing is recorded only
+// when anchored on its first candidate, so find_xwings never double-records it).
+// Same board as the row-based test, which finds the pattern from (0,1); from
+// (0,5) it must find nothing.
+void test_xwing_anchor_not_first() {
+    std::cout << "[x-wing] anchoring on a non-first candidate finds nothing\n";
     Board board = empty_board();
     const Value V = kSeven;
-    confine_value(board, V, { {0,1},{0,5}, {3,1},{3,8}, {7,5} });
+    confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
     Analyzer analyzer(board);
-    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
-    check(!found, "no X-Wing reported when the candidate lines are misaligned");
-    check(AnalyzerTest::xwing_count(analyzer) == 0, "no X-Wing recorded");
+    check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 5), V),
+          "no X-Wing reported when anchored on the row's second candidate");
+    check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded from the non-first anchor");
 }
 
 // ===========================================================================
@@ -475,6 +507,7 @@ int main() {
     test_xwing_column_based();
     test_xwing_no_elimination();
     test_xwing_misaligned_not_found();
+    test_xwing_anchor_not_first();
     test_colorchain_rule2_contradiction();
     test_colorchain_benign_not_actionable();
 


### PR DESCRIPTION
## Problem

`test_xwing` (`analyzer-xwing.cpp`) was a fully-formed ~30-line rectangle-validator with **no callers** — not in `find_xwing` (which reimplemented the same checks inline), not in `act_on_xwing`, not in the tests. It looked authoritative but was not the code that ran, and nothing tested it. Two ways to resolve a dead helper: wire it in, or delete it.

An earlier revision of this PR wired it in, on the premise that "every technique has a `find_`/`test_` pair." That premise doesn't hold: only **7 of 10** techniques have a `test_` helper, and the **3** that inline (locked candidates, hidden pair, **Swordfish**) include X-Wing's direct sibling. Swordfish is the other basic fish — same templated `Row`/`Column` structure, same `candidates()` helper — and it inlines its validation, tested by driving `find_swordfish`. Matching the fish sibling is the more locally consistent choice, so this PR **deletes** `test_xwing` instead.

## Production change

The net production diff is simply removing the dead `test_xwing` (from `analyzer-xwing.cpp` and `analyzer.h`). `find_xwing` keeps its inline validation, byte-identical to its pre-PR form.

## Test change

The technique had no whitebox coverage at all (the black-box suite only exercises it on full solves). This adds four `find_xwing`-driven cases, mirroring how the Swordfish tests drive `find_swordfish` — craft a small board, call `find_xwing` through its anchor entry point, inspect the recorded pattern and its eliminations:

- **row-based** detect + act (eliminates the column strays, keeps the corners),
- **column-based** detect + act — the transpose, covering the other orientation (anchored so the row search bails and the column search succeeds),
- a **perfect rectangle with nothing to eliminate** (must not be recorded — recording it would assert in `act`),
- **misaligned candidate lines** (share one cross-line, not both → no pattern).

New `AnalyzerTest` accessors (`find_xwing`, `act_on_xwing`, `xwing_count`/`value`/`row_based`) mirror the Swordfish ones.

## Verification
- Full CI matrix green (linux-gcc, linux-clang, macos-clang, sanitizer, coverage).
- `make unit`: all green. `make test`: 80/0.
- XWing fixture board still produces identical `[fXW]` detection and six `[XW] ... x7` eliminations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)