### PR TITLE
Push candidate-set operations onto Notes (bitmask); reserve values() for enumeration

### DIFF
--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -48,14 +48,12 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
     if (c2.notes().count() != 2) return false;
 
     // yes! but are they the same pairs of candidates?
+    // values() returns candidates ascending, so equal lists means equal pairs.
     auto c1v = c1.notes().values();
-    auto c2v = c2.notes().values();
+    if (c1v != c2.notes().values()) return false;
+
     auto v11 = c1v.at(0);
     auto v12 = c1v.at(1);
-    auto v21 = c2v.at(0);
-    auto v22 = c2v.at(1);
-
-    if (!((v11 == v21 && v12 == v22) || (v11 == v22 && v12 == v21))) return false;
 
     // yes! but would acting on them have an effet?
     if (!would_act(set, c1, c2, v11, v12)) return false;

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -47,11 +47,11 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
     if (c1.notes().count() != 2) return false;
     if (c2.notes().count() != 2) return false;
 
-    // yes! but are they the same pairs of candidates?
-    // values() returns candidates ascending, so equal lists means equal pairs.
-    auto c1v = c1.notes().values();
-    if (c1v != c2.notes().values()) return false;
+    // yes! but are they the same pairs of candidates? Both cells are bivalue
+    // (checked above), so identical candidate sets is one bitmask compare.
+    if (c1.notes() != c2.notes()) return false;
 
+    auto c1v = c1.notes().values();
     auto v11 = c1v.at(0);
     auto v12 = c1v.at(1);
 

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -155,6 +155,13 @@ bool Analyzer::act_on_naked_pair() {
     return did_act;
 }
 
+// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp)
+// can link test_naked_pair<Row> directly. Its only in-TU caller is
+// find_naked_pair, which at -O3 g++ inlines, emitting no out-of-line copy of
+// the predicate; the external reference from the test TU then fails to link
+// (clang happens to keep a weak definition, so it only bit the gcc build).
+template bool Analyzer::test_naked_pair<Row>(const Cell &, const Cell &, const Row &) const;
+
 std::ostream& operator<<(std::ostream& outs, const Analyzer::NakedPair &np) {
     return outs << "{" << np.coords.first << "," << np.coords.second << "}#{" << np.values.first << "," << np.values.second << "}";
 }

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -51,12 +51,12 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
     // (checked above), so identical candidate sets is one bitmask compare.
     if (c1.notes() != c2.notes()) return false;
 
-    auto c1v = c1.notes().values();
-    auto v11 = c1v.at(0);
-    auto v12 = c1v.at(1);
+    auto values = c1.notes().values();
+    auto v1 = values.at(0);
+    auto v2 = values.at(1);
 
     // yes! but would acting on them have an effet?
-    if (!would_act(set, c1, c2, v11, v12)) return false;
+    if (!would_act(set, c1, c2, v1, v2)) return false;
 
     // yes!
     return true;

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -100,8 +100,7 @@ namespace {
             if (cell.notes().count() != 2) continue;
 
             // yes! but is one of the candidates also a candidate for pivot?
-            const auto cell_values = cell.notes().values();
-            if (!pivot.check(cell_values[0]) && !pivot.check(cell_values[1])) continue;
+            if (!pivot.notes().intersects(cell.notes())) continue;
 
             // yes! but are both candidates not candidates for pivot? Both cells
             // are bivalue, so identical candidate sets is one bitmask compare.

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -64,15 +64,10 @@ bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing
     // skipped (at least one shared), and candidates with the identical 2-value
     // set as the pivot are skipped (no more than one shared).
 
-    // which value does wing1 share with pivot?
-    const auto w1 = wing1.notes().values();
-    assert(pivot.check(w1[0]) != pivot.check(w1[1]));
-    Value wing1_shared = pivot.check(w1[0]) ? w1[0] : w1[1];
-
-    // which value does wing2 share with pivot?
-    const auto w2 = wing2.notes().values();
-    assert(pivot.check(w2[0]) != pivot.check(w2[1]));
-    Value wing2_shared = pivot.check(w2[0]) ? w2[0] : w2[1];
+    // which value does each wing share with pivot? By construction exactly one,
+    // so this is the single bit in each wing's intersection with the pivot.
+    Value wing1_shared = wing1.notes().shared_value(pivot.notes());
+    Value wing2_shared = wing2.notes().shared_value(pivot.notes());
 
     // yes! but do wing1 and wing2 share different values with pivot?
     if (wing1_shared == wing2_shared) return false;

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -94,8 +94,6 @@ namespace {
     void select_wing_candidates(const Cell &pivot, const Set &set, std::unordered_set<Cell> &wing_candidates) {
         assert(set.contains(pivot));
 
-        const auto pivot_values = pivot.notes().values();
-
         for (auto const &cell : set) {
             // is this another cell than the pivot?
             if (cell == pivot) continue;
@@ -110,8 +108,9 @@ namespace {
             const auto cell_values = cell.notes().values();
             if (!pivot.check(cell_values[0]) && !pivot.check(cell_values[1])) continue;
 
-            // yes! but are both candidates not candidates for pivot?
-            if (pivot_values == cell_values) continue;
+            // yes! but are both candidates not candidates for pivot? Both cells
+            // are bivalue, so identical candidate sets is one bitmask compare.
+            if (pivot.notes() == cell.notes()) continue;
 
             // yes! ok, this is a bona fide wing candidate; record it
             // unordered_set automatically handles duplicates

--- a/cell.cpp
+++ b/cell.cpp
@@ -20,6 +20,9 @@ bool Notes::set(const Value &v, bool set) {
 }
 
 ValueList Notes::values() const {
+    // value_range() is ascending, so candidates come out ascending; see the
+    // declaration for why that order is an enumeration contract, not a
+    // set-comparison invariant.
     ValueList v;
     for (Value value : value_range()) {
         if (check(value)) v.push_back(value);

--- a/cell.h
+++ b/cell.h
@@ -99,6 +99,10 @@ public:
         return static_cast<Value>(std::countr_zero<uint16_t>(mNotes & ~bit(v)) + 1);
     }
 
+    // Whether the two sets share any candidate (non-empty intersection). Unlike
+    // shared_value, zero shared candidates is a legal answer, not an assert.
+    bool intersects(const Notes &other) const { return (mNotes & other.mNotes) != 0; }
+
     // The single candidate this set shares with other. Mirror of other_value on
     // the intersection: AND the masks, require exactly one bit, read its value.
     Value shared_value(const Notes &other) const {

--- a/cell.h
+++ b/cell.h
@@ -40,9 +40,9 @@ class Cell;
 // holds at most nine candidates, so a fixed nine-slot array plus a count covers
 // every case while staying trivially copyable. This is a drop-in for the
 // std::vector<Value> that Notes::values() used to return, exposing exactly what
-// the analyzer call sites need: range iteration, indexing, size, and equality.
-// Values are stored ascending (values() fills it in value_range order), so
-// equality between two lists is a positional candidate-set comparison.
+// the analyzer call sites need: range iteration, indexing, and size. (Set
+// equality of two cells' candidates goes through Notes::operator== on the
+// bitmask, so ValueList itself needs no equality.)
 class ValueList {
 public:
     using const_iterator = const Value *;
@@ -56,12 +56,6 @@ public:
 
     const_iterator begin() const { return mData.data(); }
     const_iterator end() const { return mData.data() + mCount; }
-
-    bool operator==(const ValueList &other) const {
-        if (mCount != other.mCount) return false;
-        for (size_t i = 0; i < mCount; ++i) if (mData[i] != other.mData[i]) return false;
-        return true;
-    }
 
 private:
     std::array<Value, 9> mData {};
@@ -81,6 +75,11 @@ public:
     bool check(const Value &v) const { return (mNotes & bit(v)) != 0; }
     bool set(const Value &v, bool set);
     bool set_all(bool set) { mNotes = set ? kAllCandidates : 0; return true; }
+
+    // Two note sets are equal iff they hold the same candidates. The bitmask is
+    // the canonical set representation, so this is one integer compare -- order-
+    // blind and independent of how the candidates were set.
+    bool operator==(const Notes &other) const { return mNotes == other.mNotes; }
 
     size_t count() const { return std::popcount(mNotes); }
     ValueList values() const;

--- a/cell.h
+++ b/cell.h
@@ -82,6 +82,13 @@ public:
     bool operator==(const Notes &other) const { return mNotes == other.mNotes; }
 
     size_t count() const { return std::popcount(mNotes); }
+
+    // Enumerate the candidates, ascending. The ascending order is an
+    // enumeration-order contract (stable board display; canonical NakedPair
+    // value tuples so dedup compares like with like), NOT a correctness
+    // invariant for comparing two sets: candidate-set questions go through the
+    // bitmask directly (operator==, shared_value, other_value), so no consumer's
+    // correctness depends on the order here. Reserve values() for iteration.
     ValueList values() const;
 
     // For a two-candidate cell, the candidate that isn't v. Clearing v's bit
@@ -90,6 +97,14 @@ public:
         assert(count() == 2);
         assert(check(v));
         return static_cast<Value>(std::countr_zero<uint16_t>(mNotes & ~bit(v)) + 1);
+    }
+
+    // The single candidate this set shares with other. Mirror of other_value on
+    // the intersection: AND the masks, require exactly one bit, read its value.
+    Value shared_value(const Notes &other) const {
+        uint16_t both = mNotes & other.mNotes;
+        assert(std::popcount(both) == 1);
+        return static_cast<Value>(std::countr_zero(both) + 1);
     }
 
 private:

--- a/cell.h
+++ b/cell.h
@@ -108,7 +108,7 @@ public:
     Value shared_value(const Notes &other) const {
         uint16_t both = mNotes & other.mNotes;
         assert(std::popcount(both) == 1);
-        return static_cast<Value>(std::countr_zero(both) + 1);
+        return static_cast<Value>(std::countr_zero<uint16_t>(both) + 1);
     }
 
 private:

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -90,12 +90,31 @@ matches, with one exception:
 
 ## A note on templates
 
-Of the techniques with a `test_`, only `test_ywing` is exercised *directly* by
-the unit tests — and it is the only one that is **not** templated on the unit
-type. The templated predicates (`test_naked_pair`, etc.) are tested only
-*through* their `find_`. A templated `test_` called directly across translation
-units risks GCC inlining it away with no emitted symbol, forcing explicit
-instantiations (the link failure PR #24 hit and then shed by deleting the
-predicate). So when extracting a templated predicate, decide up front: test it
-through `find_` (cheap, coarser), or pay the explicit-instantiation tax for
-direct per-branch predicate tests.
+Most `test_` predicates are templated on the unit type (`test_naked_pair`, etc.);
+`test_ywing` is the lone non-templated one. Testing a templated predicate
+*directly* (not just through its `find_`) has a known sharp edge, now settled by
+PR #27 for `test_naked_pair`:
+
+- **The failure mode.** A templated `test_` whose only in-TU caller is its
+  `find_` gets that one use inlined by g++ at `-O3`, so no out-of-line symbol is
+  emitted. A unit test referencing the predicate across the TU boundary then
+  fails to link — but *only on gcc*: clang keeps a weak definition, so the build
+  passes locally and on the macos/linux-clang legs and breaks solely on
+  linux-gcc. (PR #24 hit the same link failure from the other direction and shed
+  it by deleting a dead predicate.)
+
+- **The fix, when you want direct per-branch tests.** Add a friend hook in
+  `AnalyzerTest` that instantiates the predicate on a concrete unit (e.g.
+  `test_naked_pair_row` calls `a.test_naked_pair(c1, c2, a.mBoard.row(c1))`), and
+  add an explicit instantiation next to the definition:
+  `template bool Analyzer::test_naked_pair<Row>(const Cell &, const Cell &, const Row &) const;`.
+  The explicit instantiation forces a standalone symbol regardless of inlining.
+  Confirm on CI, not locally: the Apple-clang `g++` shim cannot reproduce the
+  gcc-only link failure.
+
+- **The decision.** When extracting a templated predicate, choose up front: test
+  it through `find_` (cheap, coarser, no link tax), or pay the friend-hook +
+  explicit-instantiation tax for direct per-branch predicate tests. The hidden
+  pair extraction (above) will face exactly this choice; `test_naked_pair` in
+  `tests/unit/test_analyzer.cpp` and `analyzer-nakedpairs.cpp` is the worked
+  example to copy.

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -314,50 +314,6 @@ void test_ywing_rejects_non_patterns() {
 }
 
 // ===========================================================================
-// ValueList
-// ===========================================================================
-
-// ValueList::operator== underpins the naked-pair pair-match check but otherwise
-// ships untested. It is positional (notes().values() always fills ascending),
-// so it is equality of same-length, same-order candidate lists.
-void test_valuelist_equality() {
-    std::cout << "[value list] positional equality of candidate lists\n";
-    ValueList a; a.push_back(kThree); a.push_back(kFive);
-    ValueList b; b.push_back(kThree); b.push_back(kFive);
-    ValueList c; c.push_back(kThree); c.push_back(kSix);
-    ValueList d; d.push_back(kThree);
-
-    check(a == b, "equal: same values in the same order");
-    check(!(a == c), "unequal: a differing element");
-    check(!(a == d), "unequal: differing length");
-}
-
-// The naked-pair pair-match check leans on notes().values() returning
-// candidates ascending (so a positional ValueList::== suffices). values() walks
-// value_range() ascending and emits the present candidates, so its order is
-// independent of how the candidates were set. Pin that down directly: a comment
-// at the call site cannot, and if the fill order ever changes this is the test
-// that catches it before the silent miscompare reaches the solver.
-void test_notes_values_ascending() {
-    std::cout << "[notes] values() returns candidates ascending, regardless of set order\n";
-    Notes n;
-    n.clear();
-    n.set(kSeven, true);   // set in deliberately scrambled order...
-    n.set(kTwo, true);
-    n.set(kFive, true);
-
-    ValueList got = n.values();
-
-    // Independent of operator==: walk the result and assert it strictly ascends.
-    bool ascending = got.size() == 3;
-    for (size_t i = 1; i < got.size(); ++i) if (!(got[i - 1] < got[i])) ascending = false;
-    check(ascending, "scrambled-insertion {7,2,5} comes back strictly ascending");
-
-    ValueList want; want.push_back(kTwo); want.push_back(kFive); want.push_back(kSeven);
-    check(got == want, "...and equals the expected [2,5,7]");
-}
-
-// ===========================================================================
 // Naked Pair
 // ===========================================================================
 
@@ -367,9 +323,8 @@ void test_notes_values_ascending() {
 // to route through a naked pair; these whitebox cases hand it crafted tuples to
 // pin down the accept and reject branches directly.
 //
-// The accept case also locks the invariant the pair-match check now leans on:
-// notes().values() returns candidates ascending and ValueList::operator== is
-// positional, so two cells holding the same two candidates compare equal.
+// The accept/reject split also exercises the pair-match check: two bivalue
+// cells are a pair iff their note bitmasks are equal (Notes::operator==).
 void test_naked_pair_accept_and_reject() {
     std::cout << "[naked pair] the predicate accepts a real pair and rejects a mismatch\n";
     Board board = empty_board();
@@ -588,8 +543,6 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
-    test_valuelist_equality();
-    test_notes_values_ascending();
     test_naked_pair_accept_and_reject();
     test_xwing_row_based();
     test_xwing_column_based();

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -331,7 +331,8 @@ void test_notes_set_ops() {
     check(!(a == c), "unequal: candidate sets {3,5} and {3,6} differ");
 
     // intersects: zero shared is a legal answer (no assert), unlike shared_value.
-    check(a.intersects(c), "intersects: {3,5} and {3,6} share 3");
+    check(a.intersects(c), "intersects: {3,5} and {3,6} share one (3)");
+    check(a.intersects(b), "intersects: {3,5} and {3,5} share two (3 and 5)");
     check(!a.intersects(d), "disjoint: {3,5} and {1,2} share nothing");
 
     // shared_value: the single common candidate.

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -332,6 +332,31 @@ void test_valuelist_equality() {
     check(!(a == d), "unequal: differing length");
 }
 
+// The naked-pair pair-match check leans on notes().values() returning
+// candidates ascending (so a positional ValueList::== suffices). values() walks
+// value_range() ascending and emits the present candidates, so its order is
+// independent of how the candidates were set. Pin that down directly: a comment
+// at the call site cannot, and if the fill order ever changes this is the test
+// that catches it before the silent miscompare reaches the solver.
+void test_notes_values_ascending() {
+    std::cout << "[notes] values() returns candidates ascending, regardless of set order\n";
+    Notes n;
+    n.clear();
+    n.set(kSeven, true);   // set in deliberately scrambled order...
+    n.set(kTwo, true);
+    n.set(kFive, true);
+
+    ValueList got = n.values();
+
+    // Independent of operator==: walk the result and assert it strictly ascends.
+    bool ascending = got.size() == 3;
+    for (size_t i = 1; i < got.size(); ++i) if (!(got[i - 1] < got[i])) ascending = false;
+    check(ascending, "scrambled-insertion {7,2,5} comes back strictly ascending");
+
+    ValueList want; want.push_back(kTwo); want.push_back(kFive); want.push_back(kSeven);
+    check(got == want, "...and equals the expected [2,5,7]");
+}
+
 // ===========================================================================
 // Naked Pair
 // ===========================================================================
@@ -564,6 +589,7 @@ int main() {
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
     test_valuelist_equality();
+    test_notes_values_ascending();
     test_naked_pair_accept_and_reject();
     test_xwing_row_based();
     test_xwing_column_based();

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -314,6 +314,31 @@ void test_ywing_rejects_non_patterns() {
 }
 
 // ===========================================================================
+// Notes set operations
+// ===========================================================================
+
+// The bitmask set primitives the analyzers now lean on (#28). Tested directly,
+// not just through their call sites, so a regression names the primitive.
+void test_notes_set_ops() {
+    std::cout << "[notes] bitmask set operations: ==, intersects, shared_value\n";
+    Notes a; a.clear(); a.set(kThree, true); a.set(kFive, true);   // {3,5}
+    Notes b; b.clear(); b.set(kFive, true);  b.set(kThree, true);  // {3,5}, set reversed
+    Notes c; c.clear(); c.set(kThree, true); c.set(kSix, true);    // {3,6}, overlaps a on 3
+    Notes d; d.clear(); d.set(kOne, true);   d.set(kTwo, true);    // {1,2}, disjoint from a
+
+    // operator== is set equality on the mask: order-insensitive, both directions.
+    check(a == b && b == a, "equal: same candidates regardless of set order");
+    check(!(a == c), "unequal: candidate sets {3,5} and {3,6} differ");
+
+    // intersects: zero shared is a legal answer (no assert), unlike shared_value.
+    check(a.intersects(c), "intersects: {3,5} and {3,6} share 3");
+    check(!a.intersects(d), "disjoint: {3,5} and {1,2} share nothing");
+
+    // shared_value: the single common candidate.
+    check(a.shared_value(c) == kThree, "shared_value: {3,5} and {3,6} share 3");
+}
+
+// ===========================================================================
 // Naked Pair
 // ===========================================================================
 
@@ -321,28 +346,44 @@ void test_ywing_rejects_non_patterns() {
 // docs/test-predicate-idiom.md): find_ enumerates cell pairs, the predicate
 // judges each. The black-box suite only reaches it on a real solve that happens
 // to route through a naked pair; these whitebox cases hand it crafted tuples to
-// pin down the accept and reject branches directly.
+// pin down its branches directly.
 //
-// The accept/reject split also exercises the pair-match check: two bivalue
-// cells are a pair iff their note bitmasks are equal (Notes::operator==).
+// test_naked_pair is a composite: it accepts only a genuine pair (Notes::==)
+// that is *also* actionable (would_act). Those two gates are tested separately
+// below so a would_act change surfaces as an actionability failure, not a
+// phantom pair-match regression.
 void test_naked_pair_accept_and_reject() {
-    std::cout << "[naked pair] the predicate accepts a real pair and rejects a mismatch\n";
+    std::cout << "[naked pair] the pair-match and actionability gates\n";
+
+    // --- pair-match gate ---
+    // Every other cell in the row carries all nine candidates, so any genuine
+    // pair here is trivially actionable; this isolates the pair-match decision.
     Board board = empty_board();
     set_candidates(board, 0, 0, {3, 5});   // the pair...
     set_candidates(board, 0, 1, {3, 5});   // ...its twin in the same row
     set_candidates(board, 0, 2, {3, 6});   // shares only one value -- not a pair
-    // Every other cell in row 0 still carries all nine candidates, so a genuine
-    // pair has somewhere to act and would_act() does not veto the accept case.
-
     Analyzer analyzer(board);
 
-    bool accepted = AnalyzerTest::test_naked_pair_row(analyzer,
-        cell_at(board, 0, 0), cell_at(board, 0, 1));
-    check(accepted, "accepted: two cells holding the same candidate pair {3,5}");
+    check(AnalyzerTest::test_naked_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1)),
+          "accepted: two cells holding the same candidate pair {3,5}");
+    // Reject short-circuits on the set compare, before would_act: a pure
+    // pair-match check, immune to changes in actionability logic.
+    check(!AnalyzerTest::test_naked_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 2)),
+          "rejected: candidate sets {3,5} and {3,6} differ");
 
-    bool rejected = AnalyzerTest::test_naked_pair_row(analyzer,
-        cell_at(board, 0, 0), cell_at(board, 0, 2));
-    check(!rejected, "rejected: candidate sets {3,5} and {3,6} differ");
+    // --- actionability gate (would_act) ---
+    // Same shape of matching pair, but its two values live nowhere else in the
+    // row, so there is nothing to eliminate and the predicate must decline. This
+    // pins the would_act gate explicitly rather than leaning on it implicitly.
+    Board inert = empty_board();
+    set_candidates(inert, 0, 0, {7, 8});
+    set_candidates(inert, 0, 1, {7, 8});
+    confine_value(inert, kSeven, { {0, 0}, {0, 1} });
+    confine_value(inert, kEight, { {0, 0}, {0, 1} });
+    Analyzer inert_analyzer(inert);
+
+    check(!AnalyzerTest::test_naked_pair_row(inert_analyzer, cell_at(inert, 0, 0), cell_at(inert, 0, 1)),
+          "rejected: a real pair with nothing to act on (would_act gate)");
 }
 
 // ===========================================================================
@@ -543,6 +584,7 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
+    test_notes_set_ops();
     test_naked_pair_accept_and_reject();
     test_xwing_row_based();
     test_xwing_column_based();

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -86,6 +86,14 @@ struct AnalyzerTest {
     static bool   xwing_row_based(const Analyzer &a)                     { return a.mXWings.at(0).is_row_based; }
     static Value  xwing_value(const Analyzer &a)                         { return a.mXWings.at(0).value; }
 
+    // --- naked pair ---
+    // test_naked_pair is given-tuple shaped: find_ enumerates cell pairs and the
+    // predicate judges each. Drive it directly on a crafted unit. It is a
+    // template on the set type; instantiate it on the cells' shared Row.
+    static bool test_naked_pair_row(const Analyzer &a, const Cell &c1, const Cell &c2) {
+        return a.test_naked_pair(c1, c2, a.mBoard.row(c1));
+    }
+
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
     static bool act_on_color_chain(Analyzer &a)                                     { return a.act_on_color_chain(); }
@@ -306,6 +314,58 @@ void test_ywing_rejects_non_patterns() {
 }
 
 // ===========================================================================
+// ValueList
+// ===========================================================================
+
+// ValueList::operator== underpins the naked-pair pair-match check but otherwise
+// ships untested. It is positional (notes().values() always fills ascending),
+// so it is equality of same-length, same-order candidate lists.
+void test_valuelist_equality() {
+    std::cout << "[value list] positional equality of candidate lists\n";
+    ValueList a; a.push_back(kThree); a.push_back(kFive);
+    ValueList b; b.push_back(kThree); b.push_back(kFive);
+    ValueList c; c.push_back(kThree); c.push_back(kSix);
+    ValueList d; d.push_back(kThree);
+
+    check(a == b, "equal: same values in the same order");
+    check(!(a == c), "unequal: a differing element");
+    check(!(a == d), "unequal: differing length");
+}
+
+// ===========================================================================
+// Naked Pair
+// ===========================================================================
+
+// test_naked_pair is the archetypal given-tuple predicate (see
+// docs/test-predicate-idiom.md): find_ enumerates cell pairs, the predicate
+// judges each. The black-box suite only reaches it on a real solve that happens
+// to route through a naked pair; these whitebox cases hand it crafted tuples to
+// pin down the accept and reject branches directly.
+//
+// The accept case also locks the invariant the pair-match check now leans on:
+// notes().values() returns candidates ascending and ValueList::operator== is
+// positional, so two cells holding the same two candidates compare equal.
+void test_naked_pair_accept_and_reject() {
+    std::cout << "[naked pair] the predicate accepts a real pair and rejects a mismatch\n";
+    Board board = empty_board();
+    set_candidates(board, 0, 0, {3, 5});   // the pair...
+    set_candidates(board, 0, 1, {3, 5});   // ...its twin in the same row
+    set_candidates(board, 0, 2, {3, 6});   // shares only one value -- not a pair
+    // Every other cell in row 0 still carries all nine candidates, so a genuine
+    // pair has somewhere to act and would_act() does not veto the accept case.
+
+    Analyzer analyzer(board);
+
+    bool accepted = AnalyzerTest::test_naked_pair_row(analyzer,
+        cell_at(board, 0, 0), cell_at(board, 0, 1));
+    check(accepted, "accepted: two cells holding the same candidate pair {3,5}");
+
+    bool rejected = AnalyzerTest::test_naked_pair_row(analyzer,
+        cell_at(board, 0, 0), cell_at(board, 0, 2));
+    check(!rejected, "rejected: candidate sets {3,5} and {3,6} differ");
+}
+
+// ===========================================================================
 // X-Wing
 // ===========================================================================
 
@@ -503,6 +563,8 @@ int main() {
     test_xychain_best_selection();
     test_ywing_detect_and_act();
     test_ywing_rejects_non_patterns();
+    test_valuelist_equality();
+    test_naked_pair_accept_and_reject();
     test_xwing_row_based();
     test_xwing_column_based();
     test_xwing_no_elimination();


### PR DESCRIPTION
Closes #28.

## Problem

`Notes` *is* the candidate set: nine flags in a `uint16_t` bitmask. But several questions that are inherently about that set ("do these two cells hold the same pair?", "which value does this wing share with the pivot?", "do these two cells share any candidate?") were answered by first enumerating the set to a `ValueList` via `notes().values()` and then indexing or comparing the list positionally. That makes `values()`' ascending order quietly load-bearing for correctness, which is the wrong layer: a set question should be answered on the set.

## Change

Give `Notes` the set operations its call sites actually want (mirroring the existing `other_value` precedent), migrate every set-predicate site onto them, and reserve `values()` for genuine enumeration.

New `Notes` operations, all directly on the mask:

- **`operator==`** (`mNotes == other.mNotes`) — candidate-set equality, O(1), order-blind.
- **`intersects(const Notes &)`** — non-empty intersection (`(a & b) != 0`); zero shared candidates is a legal answer.
- **`shared_value(const Notes &)`** — the single candidate two sets share (AND the masks, require exactly one bit, read its value).

Set-predicate sites migrated off `values()` + positional indexing:

| Site | Now |
|---|---|
| naked-pair pair-match (`test_naked_pair`) | `c1.notes() != c2.notes()` |
| y-wing wing-candidate guard (`select_wing_candidates`) | `pivot.notes() == cell.notes()` |
| y-wing pivot/cell overlap test (`select_wing_candidates`) | `pivot.notes().intersects(cell.notes())` |
| y-wing shared/elimination value (`test_ywing`) | `wing.notes().shared_value(pivot.notes())` |

With every set question off the list, y-wing no longer calls `values()` at all — the whole technique answers its candidate-set questions on the bitmask. The "exactly one shared" precondition that `test_ywing` asserted by hand folds into `shared_value`'s `popcount==1`.

`values()`' docstring is reframed accordingly: its ascending order is an **enumeration-order contract** (stable board display; canonical `NakedPair` value tuples for dedup), explicitly **not** a correctness invariant for comparing sets. Tracing every consumer confirms none depends on the order for correctness anymore.

## What stays on `values()` (genuine enumeration)

Iteration sites are unchanged and order-agnostic: hidden pairs, swordfish, x-wing, xy-chain (each loops/acts over candidates), and naked single (`count()==1`).

## Tests

- **`test_notes_set_ops`** covers the three primitives directly: `operator==` both directions and order-insensitive, `intersects` with single- and two-candidate overlap and with disjoint sets, `shared_value` returning the shared bit.
- **`test_naked_pair_accept_and_reject`** drives the predicate through a new `AnalyzerTest::test_naked_pair_row` friend hook, splitting its two gates: the reject case short-circuits on the set compare (pure pair-match), and an inert-board case (a real pair whose values live nowhere else in the row) pins the `would_act` actionability gate on its own — so a `would_act` change reads as an actionability failure, not a phantom pair-match regression. First whitebox coverage for naked pair.
- Existing y-wing whitebox tests (`test_ywing_detect_and_act`, `test_ywing_rejects_non_patterns`) cover the migrated `shared_value` / `intersects` paths, including the near-miss cases.

The friend hook is the first templated `test_` exercised across a TU boundary, so it needs an explicit `test_naked_pair<Row>` instantiation (g++ at `-O3` inlines the predicate's only in-TU use and emits no standalone symbol; clang masks it with a weak definition). `docs/test-predicate-idiom.md` records the pattern.

## Scope / non-goals

Per #28: `ValueList` stays (enumeration sites keep it); not the find/act or Technique-interface refactors (#7/#8/#9); orthogonal to the templated-`test_` machinery.

## Test plan

- `make test` — 80/80 integration tests pass
- `make unit` — all whitebox checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)