### PR TITLE
find_xwings/find_swordfish: drop did_find flag, adopt range-based loop

### DIFF
--- a/analyzer-swordfish.cpp
+++ b/analyzer-swordfish.cpp
@@ -169,26 +169,19 @@ bool Analyzer::find_swordfish() {
     // and all these candidates lie in the same three columns (or rows),
     // then all other candidates for that value in those columns (or rows) can be eliminated.
 
-    bool did_find = false;
-
     for (auto const &cell: mBoard.cells()) {
         // is this a note cell?
         if (!cell.isNote()) continue;
 
         // for each value in this cell...
-        auto values = cell.notes().values();
-        for (auto pv = values.begin(); pv != values.end(); ++pv) {
-            // let's see if we can anchor a Swordfish pattern in this cell for this value
-            did_find = find_swordfish(cell, *pv);
-            if (!did_find) continue;
-            break;
+        for (auto const &value : cell.notes().values()) {
+            // let's see if we can anchor a Swordfish pattern in this cell for this value;
+            // stop at the first one found
+            if (find_swordfish(cell, value)) return true;
         }
-
-        if (!did_find) continue;
-        break;
     }
 
-    return did_find;
+    return false;
 }
 
 template<class CandidateSet, class EliminationSet>

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -109,11 +109,10 @@ bool Analyzer::find_xwings() {
         if (!cell.isNote()) continue;
 
         // for each value in this cell...
-        auto values = cell.notes().values();
-        for (auto pv = values.begin(); pv != values.end(); ++pv) {
+        for (auto const &value : cell.notes().values()) {
             // let's see if we can anchor an X-Wing pattern in this cell for this value;
             // stop at the first one found
-            if (find_xwing(cell, *pv)) return true;
+            if (find_xwing(cell, value)) return true;
         }
     }
 

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -104,8 +104,6 @@ bool Analyzer::find_xwings() {
     // When there are only two possible cells for a value in each of two different rows,
     // and these candidates lie also in the same columns, then all other candidates for
     // this value in the columns can be eliminated.
-    bool did_find = false;
-
     for (auto const &cell: mBoard.cells()) {
         // is this a note cell?
         if (!cell.isNote()) continue;
@@ -113,17 +111,13 @@ bool Analyzer::find_xwings() {
         // for each value in this cell...
         auto values = cell.notes().values();
         for (auto pv = values.begin(); pv != values.end(); ++pv) {
-            // let's see if we can anchor an X-Wing pattern in this cell for this value
-            did_find = find_xwing(cell, *pv);
-            if (!did_find) continue;
-            break;
+            // let's see if we can anchor an X-Wing pattern in this cell for this value;
+            // stop at the first one found
+            if (find_xwing(cell, *pv)) return true;
         }
-
-        if (!did_find) continue;
-        break;
     }
 
-    return did_find;
+    return false;
 }
 
 template<class CandidateSet, class EliminationSet>


### PR DESCRIPTION
## What

Simplifies the structurally identical anchor-search loops in `find_xwings()` and `find_swordfish()` (the zero-arg driver overload, `analyzer-swordfish.cpp:165`).

Both functions carried a `did_find` bool solely to signal "stop" back out through two loop levels, producing two awkward `if (!did_find) continue; break;` pairs each (one for the value loop, one for the cell loop). Since both return `bool` anyway, returning `true` at the hit site collapses the pairs and removes the flag. With the flag gone, the inner loop's explicit-iterator form no longer earns its keep either, so it adopts the range-based loop the sibling analyzers already use:

```cpp
for (auto const &cell: mBoard.cells()) {
    if (!cell.isNote()) continue;

    // for each value in this cell; stop at the first one found
    for (auto const &value : cell.notes().values()) {
        if (find_xwing(cell, value)) return true;
    }
}

return false;
```

## Why it's safe

The only behavioral risk in turning `break` into `return true` is if iteration *after* the first hit was doing something the new code now skips. It wasn't: in the old code the hit also stopped iteration (`did_find = true` immediately followed by `break` out of the inner loop, then `break` out of the outer loop), so no further `find_xwing` / `find_swordfish` anchor calls ran after a hit either. The anchor overload is the only side-effecting call in the loop body (it records the found pattern into `mXWings` / `mSwordfish`), and the count of those calls before the first hit is unchanged. So `return true` runs exactly the same calls, in the same order, as the old flag-and-break — it just skips re-checking a flag that was already known true.

`ValueList` (cell.h) is a trivially-copyable value type with `begin()/end()`, so iterating the temporary directly is safe — matching the idiom in `analyzer-hiddensingles.cpp`, `analyzer-lockedcandidates.cpp`, and `analyzer-hiddenpairs.cpp`.

Both drivers get the identical treatment, so the two twins stay in sync rather than diverging. (Note the pre-existing naming asymmetry, untouched here: X-Wing pluralizes its driver, `find_xwings()`, while Swordfish overloads on signature, `find_swordfish()`.)

## Testing

`make test` (80/80 integration) and `make unit` (whitebox) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)