### PR TITLE
Naked/Hidden Pair: two readability/efficiency nits

### DIFF
--- a/analyzer-hiddenpairs.cpp
+++ b/analyzer-hiddenpairs.cpp
@@ -81,7 +81,7 @@ bool Analyzer::find_hidden_pairs() {
 
         // yes! but does it have at least two candidate values?
         auto values = cell.notes().values();
-        if (!(values.size() >= 2)) continue;
+        if (values.size() < 2) continue;
 
         // for each pair of candidates for this cell...
         for (auto pv1 = values.begin(); pv1 != values.end(); ++pv1) {

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -66,12 +66,14 @@ template<class Set>
 bool Analyzer::find_naked_pair(const Cell &cell, const Set &set) {
     bool did_find = false;
 
+    // cell is fixed across the loop, so its candidate pair is too; enumerate once.
+    auto cellv = cell.notes().values();
+
     for (auto const &pair_cell : set) {
         // is this candidate pair cell good?
         if (!test_naked_pair(cell, pair_cell, set)) continue;
 
         // yes! but is it already recorded?
-        auto cellv = cell.notes().values();
         NakedPair np({cell.coord(), pair_cell.coord()}, {cellv.at(0), cellv.at(1)});
         if (std::find(mNakedPairs.begin(), mNakedPairs.end(), np) != mNakedPairs.end()) continue;
 


### PR DESCRIPTION
Two trivial cleanups surfaced during the heuristics review that no open issue tracks. Both are behavior-preserving.

### `find_naked_pair` — hoist the loop-invariant enumeration
`cell` is fixed across the `pair_cell` loop, so `cell.notes().values()` is loop-invariant. It was re-enumerated on every matching `pair_cell`; now enumerated once above the loop.

### `find_hidden_pairs` — drop the double negative
`if (!(values.size() >= 2))` → `if (values.size() < 2)`.

### Testing
- `make test` — 80/80 pass
- `make unit` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)