### PR TITLE
Hidden pair: extract test_hidden_pair predicate, drop inline scan (#25)

### DIFF
--- a/analyzer-hiddenpairs.cpp
+++ b/analyzer-hiddenpairs.cpp
@@ -8,62 +8,66 @@
 #include <algorithm>
 
 template<class Set>
-bool Analyzer::find_hidden_pair(const Cell &cell, const Value &v1, const Value &v2, const Set &set) {
-    assert(cell.isNote());
-    assert(cell.notes().check(v1));
-    assert(cell.notes().check(v2));
+bool Analyzer::test_hidden_pair(const Cell &c1, const Cell &c2,
+                                const Value &v1, const Value &v2, const Set &set) const {
+    // are these two different cells, carrying two different values?
+    if (c1 == c2) return false;
+    if (v1 == v2) return false;
 
-    bool did_find = false;
+    // yes! but is v2 strictly "after" v1? (find_ enumerates v1<v2; the friend
+    // hook can pass them either way, so the predicate guards the precondition
+    // itself. The v1==v2 case above is the other half of that guard.)
+    if (v2 < v1) return false;
 
-    // can we find another note cell with the same pair in the same set,
-    // but no other cell with either candidate in the set?
-    Cell *ppair_cell = nullptr; // "the" other potential candidate
-    bool condition_met = true;
+    // yes! but is c2 "after" c1?
+    if (c2.coord() < c1.coord()) return false;
 
-    for (auto &other_cell : set) {
-        // is this other cell a note cell?
+    // yes! but are both cells in the same set?
+    if (!set.contains(c1)) return false;
+    if (!set.contains(c2)) return false;
+
+    // yes! but are both cells notes?
+    if (!c1.isNote()) return false;
+    if (!c2.isNote()) return false;
+
+    // yes! but do both cells carry the candidate pair?
+    if (!c1.check(v1) || !c1.check(v2)) return false;
+    if (!c2.check(v1) || !c2.check(v2)) return false;
+
+    // yes! but is the pair "hidden", i.e. no other cell in the set carries
+    // either value? (A stray cell carrying exactly one value, or a third cell
+    // carrying both, are equally disqualifying -- this one test subsumes both
+    // rejection paths the old discovery scan handled separately.)
+    for (auto const &other_cell : set) {
         if (!other_cell.isNote()) continue;
-
-        // yes! but is it a different cell?
-        if (other_cell == cell) continue;
-
-        // yes! but are the values possible candidates for it?
-        if (!other_cell.check(v1) && !other_cell.check(v2)) continue;                      // no impact on algorithm; check next cell in row
-        if (other_cell.check(v1) ^ other_cell.check(v2)) { condition_met = false; break; } // either v1 or v2 is disqualified
-        assert(other_cell.check(v1) && other_cell.check(v2));
-
-        // yes! but did we already find a pair candidate cell for this hidden pair?
-        if (ppair_cell) {
-            condition_met = false;      // this is disqualifying: we have more than two candidates in the row
-            break;
-        }
-
-        // this is "the" other candidate
-        ppair_cell = &other_cell;
+        if (other_cell == c1 || other_cell == c2) continue;
+        if (other_cell.check(v1) || other_cell.check(v2)) return false;
     }
-    if (!condition_met) return did_find;
 
-    // did we, in fact, find another candidate?
-    if (!ppair_cell) return did_find;
+    // yes! but is it actionable (i.e. *not* a naked pair, with nothing else to strip)?
+    if (c1.notes().count() == 2 && c2.notes().count() == 2) return false;
 
-    // yes! but is this other cell "after" this cell
-    if (ppair_cell->coord() < cell.coord()) return did_find;
+    // yes!
+    return true;
+}
 
-    // and also, is the candidate pair we found actionable (i.e. is it *not* a naked pair)?
-    if (cell.notes().count() == 2 && ppair_cell->notes().count() == 2) return did_find;
+template<class Set>
+bool Analyzer::find_hidden_pair(const Cell &cell, const Value &v1, const Value &v2, const Set &set) {
+    for (auto const &other_cell : set) {
+        // is this candidate hidden pair good?
+        if (!test_hidden_pair(cell, other_cell, v1, v2, set)) continue;
 
-    // yes! but is the entry duplicated?
-    assert(cell.coord() < ppair_cell->coord());
-    assert(v2 > v1);
-    HiddenPair hp(std::make_pair(cell.coord(), ppair_cell->coord()), std::make_pair(v1, v2));
-    if (std::find(mHiddenPairs.begin(), mHiddenPairs.end(), hp) != mHiddenPairs.end()) return did_find;
+        // yes! but is it already recorded?
+        HiddenPair hp({cell.coord(), other_cell.coord()}, {v1, v2});
+        if (std::find(mHiddenPairs.begin(), mHiddenPairs.end(), hp) != mHiddenPairs.end()) continue;
 
-    // yes! let's record the entry
-    mHiddenPairs.push_back(hp);
-    if (sVerbose) std::cout << "  [fHP] " << hp << std::endl;
-    did_find = true;
+        // no! let's record it
+        mHiddenPairs.push_back(hp);
+        if (sVerbose) std::cout << "  [fHP] " << hp << std::endl;
+        return true;
+    }
 
-    return did_find;
+    return false;
 }
 
 bool Analyzer::find_hidden_pairs() {
@@ -134,6 +138,13 @@ bool Analyzer::act_on_hidden_pair() {
     assert(did_act);
     return did_act;
 }
+
+// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp)
+// can link test_hidden_pair<Row> directly. Its only in-TU caller is
+// find_hidden_pair, which at -O3 g++ inlines, emitting no out-of-line copy of
+// the predicate; the external reference from the test TU then fails to link
+// (clang happens to keep a weak definition, so it only bit the gcc build).
+template bool Analyzer::test_hidden_pair<Row>(const Cell &, const Cell &, const Value &, const Value &, const Row &) const;
 
 std::ostream& operator<<(std::ostream& outs, const Analyzer::HiddenPair &hp) {
     return outs << "{" << hp.coords.first << "," << hp.coords.second << "}#{" << hp.values.first << "," << hp.values.second << "}";

--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -64,8 +64,6 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
 
 template<class Set>
 bool Analyzer::find_naked_pair(const Cell &cell, const Set &set) {
-    bool did_find = false;
-
     // cell is fixed across the loop, so its candidate pair is too; enumerate once.
     auto cellv = cell.notes().values();
 
@@ -80,11 +78,10 @@ bool Analyzer::find_naked_pair(const Cell &cell, const Set &set) {
         // no! let's record it
         mNakedPairs.push_back(np);
         if (sVerbose) std::cout << "  [fNP] " << np << std::endl;
-        did_find = true;
-        break;
+        return true;
     }
 
-    return did_find;
+    return false;
 }
 
 bool Analyzer::find_naked_pairs() {

--- a/analyzer.h
+++ b/analyzer.h
@@ -148,6 +148,8 @@ private:
 
     // find
     template<class Set>
+    bool test_hidden_pair(const Cell &, const Cell &, const Value &, const Value &, const Set &) const;
+    template<class Set>
     bool find_hidden_pair(const Cell &, const Value &v1, const Value &v2, const Set &);
     bool find_hidden_pairs();
 

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -70,16 +70,15 @@ call `find_`, inspect the recorded pattern).
 ## Current state vs. the rule
 
 The partition the rule predicts is 7 with `test_` (5 given-tuple + 2
-materialized-object) and 3 inline (the 3 scan-fused). The codebase very nearly
-matches, with one exception:
+materialized-object) and 3 inline (the 3 scan-fused). The codebase matches:
 
-- **Hidden pair is mis-classified.** It is given-tuple shaped (identity is
+- **Hidden pair is correctly factored.** It is given-tuple shaped (identity is
   `(c1, c2, v1, v2)`; the "no other cell in the unit carries v1 or v2" condition
   is just validation of a given tuple, exactly like naked pair's would-act
-  check), yet it currently validates inline with hand-rolled
-  `condition_met` / `ppair_cell` single-pass bookkeeping. It should be extracted
-  to a `test_hidden_pair` mirroring `test_naked_pair`. Tracked as a separate
-  issue.
+  check), and it is extracted to a `test_hidden_pair` mirroring `test_naked_pair`
+  (the old hand-rolled `condition_met` / `ppair_cell` single-pass bookkeeping is
+  gone). Like naked pair, the templated predicate is tested directly via a friend
+  hook plus an explicit `Row` instantiation (see "A note on templates" below).
 
 - **X-Wing correctly has no `test_`.** It is scan-fused; PR #24 removed the dead
   predicate and kept `find_xwing` inline, tested through `find_` like its fish
@@ -114,7 +113,7 @@ PR #27 for `test_naked_pair`:
 
 - **The decision.** When extracting a templated predicate, choose up front: test
   it through `find_` (cheap, coarser, no link tax), or pay the friend-hook +
-  explicit-instantiation tax for direct per-branch predicate tests. The hidden
-  pair extraction (above) will face exactly this choice; `test_naked_pair` in
-  `tests/unit/test_analyzer.cpp` and `analyzer-nakedpairs.cpp` is the worked
-  example to copy.
+  explicit-instantiation tax for direct per-branch predicate tests.
+  `test_naked_pair` and `test_hidden_pair` (in `tests/unit/test_analyzer.cpp`,
+  `analyzer-nakedpairs.cpp`, and `analyzer-hiddenpairs.cpp`) both took the second
+  route and are the worked examples to copy.

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -94,6 +94,14 @@ struct AnalyzerTest {
         return a.test_naked_pair(c1, c2, a.mBoard.row(c1));
     }
 
+    // --- hidden pair ---
+    // test_hidden_pair is given-tuple shaped too (identity is (c1,c2,v1,v2)):
+    // find_ enumerates the partner, the predicate judges each. Drive it directly
+    // on a crafted Row, the same way as naked pair.
+    static bool test_hidden_pair_row(const Analyzer &a, const Cell &c1, const Cell &c2, const Value &v1, const Value &v2) {
+        return a.test_hidden_pair(c1, c2, v1, v2, a.mBoard.row(c1));
+    }
+
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
     static bool act_on_color_chain(Analyzer &a)                                     { return a.act_on_color_chain(); }
@@ -388,6 +396,86 @@ void test_naked_pair_accept_and_reject() {
 }
 
 // ===========================================================================
+// Hidden pair
+// ===========================================================================
+
+// test_hidden_pair is given-tuple shaped like test_naked_pair (see
+// docs/test-predicate-idiom.md): find_ enumerates the partner cell, the
+// predicate judges each (c1,c2,v1,v2). These cases pin down its substantive
+// branches -- value ordering, cell ordering, the hidden loop, actionability,
+// and partner incompleteness -- and leave the trivial distinctness/shape guards
+// (c1 == c2, v1 == v2, set membership, isNote, c1 failing to carry the pair)
+// untested, as the test_naked_pair sibling does. Most of these branches are
+// also hit incidentally by any black-box solve, since find_hidden_pair feeds
+// every unfiltered cell to the predicate; the one find_ genuinely cannot reach
+// is value ordering
+// (find_hidden_pairs enumerates pv2 = pv1 + 1, so v1 < v2 always holds), which
+// is the load-bearing reason to test the predicate directly rather than only
+// through find_.
+void test_hidden_pair_accept_and_reject() {
+    std::cout << "[hidden pair] the hidden, actionability, ordering and partner gates\n";
+
+    // --- "hidden" gate ---
+    // (0,0) and (0,1) carry {3,5} among all nine candidates; 3 and 5 live
+    // nowhere else, so the pair is genuinely hidden and actionable (each cell
+    // still holds seven other candidates to strip).
+    Board board = empty_board();
+    confine_value(board, kThree, { {0, 0}, {0, 1} });
+    confine_value(board, kFive,  { {0, 0}, {0, 1} });
+    Analyzer analyzer(board);
+
+    check(AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1), kThree, kFive),
+          "accepted: {3,5} confined to two cells, each with more to strip");
+
+    // A third cell in the row carrying just one of the values breaks "hidden".
+    Board stray = empty_board();
+    confine_value(stray, kThree, { {0, 0}, {0, 1}, {0, 2} });
+    confine_value(stray, kFive,  { {0, 0}, {0, 1} });
+    Analyzer stray_analyzer(stray);
+
+    check(!AnalyzerTest::test_hidden_pair_row(stray_analyzer, cell_at(stray, 0, 0), cell_at(stray, 0, 1), kThree, kFive),
+          "rejected: a third cell carries 3, so {3,5} is not hidden");
+
+    // --- actionability gate ---
+    // Same hidden {3,5}, but both cells are bivalue: that is a naked pair, with
+    // nothing for hidden pair to eliminate.
+    Board naked = empty_board();
+    set_candidates(naked, 0, 0, {3, 5});
+    set_candidates(naked, 0, 1, {3, 5});
+    confine_value(naked, kThree, { {0, 0}, {0, 1} });
+    confine_value(naked, kFive,  { {0, 0}, {0, 1} });
+    Analyzer naked_analyzer(naked);
+
+    check(!AnalyzerTest::test_hidden_pair_row(naked_analyzer, cell_at(naked, 0, 0), cell_at(naked, 0, 1), kThree, kFive),
+          "rejected: both cells bivalue {3,5} -- a naked pair, nothing to strip");
+
+    // --- ordering and partner gates (reuse the accepting board) ---
+    // Cell ordering: c2 must come after c1.
+    check(!AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 1), cell_at(board, 0, 0), kThree, kFive),
+          "rejected: cells passed out of order (c2 before c1)");
+
+    // Value ordering: v2 must come after v1. find_ guarantees this; the friend
+    // hook can violate it, so the guard must be tested through the hook.
+    check(!AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1), kFive, kThree),
+          "rejected: values passed out of order (v2 < v1)");
+
+    // Partner incompleteness: c2 carries only one of the two values. find_ does
+    // reach this branch (it hands every unfiltered cell to the predicate). Both
+    // values are confined to the pair so the hidden loop finds nothing: the carry
+    // gate is then the *only* thing that can reject, so deleting it would flip the
+    // case to accept -- isolating this gate rather than letting the hidden loop
+    // mask it.
+    Board partial = empty_board();
+    confine_value(partial, kThree, { {0, 0}, {0, 1} });
+    confine_value(partial, kFive,  { {0, 0} });   // 5 lives only in (0,0)
+    set_candidates(partial, 0, 1, {3});           // partner carries 3 but not 5
+    Analyzer partial_analyzer(partial);
+
+    check(!AnalyzerTest::test_hidden_pair_row(partial_analyzer, cell_at(partial, 0, 0), cell_at(partial, 0, 1), kThree, kFive),
+          "rejected: partner carries 3 but not 5");
+}
+
+// ===========================================================================
 // X-Wing
 // ===========================================================================
 
@@ -587,6 +675,7 @@ int main() {
     test_ywing_rejects_non_patterns();
     test_notes_set_ops();
     test_naked_pair_accept_and_reject();
+    test_hidden_pair_accept_and_reject();
     test_xwing_row_based();
     test_xwing_column_based();
     test_xwing_no_elimination();


### PR DESCRIPTION
Closes #25.

## What

`find_hidden_pair` validated inline with hand-rolled `condition_met` / `ppair_cell` single-pass bookkeeping to discover the partner cell, reject a third occurrence, enforce ordering, and check actionability. Hidden pair is given-tuple shaped (identity is `(c1, c2, v1, v2)`), so it belongs with naked pair, Y-Wing, and hidden single: factor validation into a pure `const test_` predicate and collapse `find_` to an enumerate-and-test loop. It was the single misfit `docs/test-predicate-idiom.md` identified.

## How

- **`test_hidden_pair`** mirrors `test_naked_pair`. The "hidden" condition becomes one `no other cell in the set carries v1 or v2` loop, which subsumes both of the old scan's rejection paths (a stray cell carrying exactly one value, and a third cell carrying both) now that the partner is *given* rather than discovered.
- **`find_hidden_pair`** becomes the flag-free, return-on-first-hit loop adopted by `find_xwings`/`find_swordfish` in #29. **`find_naked_pair`**, framed here as the sibling, is aligned to the same shape (dropping its older `did_find` / `break`) so the two pair-finders stay consistent rather than introducing a new split.
- The templated predicate is tested **directly** via an `AnalyzerTest` friend hook plus an explicit `Row` instantiation, so g++ at `-O3` emits an out-of-line symbol for the cross-TU test reference (the gcc-only link edge documented in the idiom note). The whitebox case pins all five gates in isolation. Because `find_hidden_pair` hands every unfiltered cell to the predicate, most gates are already exercised by black-box solves; the one gate `find_` genuinely cannot reach is **value ordering** (`find_hidden_pairs` enumerates `pv2 = pv1 + 1`, so `v1 < v2` always holds), which is the load-bearing reason to test the predicate directly.
- `docs/test-predicate-idiom.md` updated: hidden pair moves from "mis-classified / tracked as a separate issue" to correctly factored.

## Verification

- `make unit` — all checks pass, including the six new `[hidden pair]` gates.
- `make test` — 80/80, including the HP per-technique precision check.
- **Behavior unchanged:** full verbose solve output on the run.sh hidden-pair *and* naked-pair boards is byte-identical old-vs-new (built the prior commit in a worktree and diffed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)