### PR TITLE
Swordfish: de-duplicate elimination-set collection + drop did_find break-flag (#32)

### DIFF
--- a/analyzer-swordfish.cpp
+++ b/analyzer-swordfish.cpp
@@ -41,8 +41,6 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
     assert(cset.contains(cell));
     assert(eset.contains(cell));
 
-    bool did_find = false;
-
     // Map a set of candidate cells to the elimination lines they fall on.
     auto esets_of = [&](const std::vector<Cell> &cells) {
         std::set<const EliminationSet*> s;
@@ -53,10 +51,10 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
 
     // Check if the current candidate set has 2-3 candidates for this value
     auto cset_candidates = candidates(cset, value);
-    if (cset_candidates.size() < 2 || cset_candidates.size() > 3) return did_find;
+    if (cset_candidates.size() < 2 || cset_candidates.size() > 3) return false;
 
     // If cell is not the first candidate, we've already considered this cset
-    if (cell != cset_candidates[0]) return did_find;
+    if (cell != cset_candidates[0]) return false;
 
     // Collect elimination sets for the first candidate set
     std::set<const EliminationSet*> eset_set1 = esets_of(cset_candidates);
@@ -131,31 +129,22 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
             assert(mSwordfish.empty());
             mSwordfish.push_back(candidate_swordfish);
             if (sVerbose) std::cout << "  [fSF] " << candidate_swordfish << std::endl;
-            did_find = true;
-            break;
+            return true;
         }
-
-        if (did_find) break;
     }
 
-    return did_find;
+    return false;
 }
 
 bool Analyzer::find_swordfish(const Cell &cell, const Value &value) {
     assert(cell.isNote());
     assert(cell.check(value));
 
-    bool did_find = false;
-
-    // Try row-based Swordfish (eliminations in columns)
-    did_find = find_swordfish(cell, value, mBoard.row(cell), mBoard.column(cell), mBoard.rows(), true);
-
-    // If not found, try column-based Swordfish (eliminations in rows)
-    if (!did_find) {
-        did_find = find_swordfish(cell, value, mBoard.column(cell), mBoard.row(cell), mBoard.columns(), false);
-    }
-
-    return did_find;
+    // Try row-based Swordfish (eliminations in columns); if not found, try
+    // column-based Swordfish (eliminations in rows)
+    if (find_swordfish(cell, value, mBoard.row(cell), mBoard.column(cell), mBoard.rows(), true))
+        return true;
+    return find_swordfish(cell, value, mBoard.column(cell), mBoard.row(cell), mBoard.columns(), false);
 }
 
 bool Analyzer::find_swordfish() {

--- a/analyzer-swordfish.cpp
+++ b/analyzer-swordfish.cpp
@@ -22,6 +22,15 @@ namespace {
 
         return candidates;
     }
+
+    // Map a cell (or coordinate) to the Row or Column it lies on, selecting
+    // which by the Line type parameter. Board exposes both row()/column()
+    // overloads, so one helper serves both find and act, for cells and coords.
+    template<class Line, class CellOrCoord>
+    const Line &line_of(const Board &board, const CellOrCoord &x) {
+        if constexpr (std::is_same_v<Line, Column>) return board.column(x);
+        else                                        return board.row(x);
+    }
 }
 
 template<class CandidateSet, class EliminationSet>
@@ -34,6 +43,14 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
 
     bool did_find = false;
 
+    // Map a set of candidate cells to the elimination lines they fall on.
+    auto esets_of = [&](const std::vector<Cell> &cells) {
+        std::set<const EliminationSet*> s;
+        for (const auto &c : cells)
+            s.insert(&line_of<EliminationSet>(mBoard, c));
+        return s;
+    };
+
     // Check if the current candidate set has 2-3 candidates for this value
     auto cset_candidates = candidates(cset, value);
     if (cset_candidates.size() < 2 || cset_candidates.size() > 3) return did_find;
@@ -42,14 +59,7 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
     if (cell != cset_candidates[0]) return did_find;
 
     // Collect elimination sets for the first candidate set
-    std::set<const EliminationSet*> eset_set1;
-    for (const auto &c : cset_candidates) {
-        if constexpr (std::is_same_v<EliminationSet, Column>) {
-            eset_set1.insert(&mBoard.column(c));
-        } else {
-            eset_set1.insert(&mBoard.row(c));
-        }
-    }
+    std::set<const EliminationSet*> eset_set1 = esets_of(cset_candidates);
 
     // Search for second and third candidate sets
     for (auto const &cset2 : csets) {
@@ -61,14 +71,7 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
         if (cset2_candidates.size() < 2 || cset2_candidates.size() > 3) continue;
 
         // Collect elimination sets for second candidate set
-        std::set<const EliminationSet*> eset_set2;
-        for (const auto &c : cset2_candidates) {
-            if constexpr (std::is_same_v<EliminationSet, Column>) {
-                eset_set2.insert(&mBoard.column(c));
-            } else {
-                eset_set2.insert(&mBoard.row(c));
-            }
-        }
+        std::set<const EliminationSet*> eset_set2 = esets_of(cset2_candidates);
 
         // Union of elimination sets from first two candidate sets
         std::set<const EliminationSet*> eset_union = eset_set1;
@@ -87,14 +90,7 @@ bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const Candid
             if (cset3_candidates.size() < 2 || cset3_candidates.size() > 3) continue;
 
             // Collect elimination sets for third candidate set
-            std::set<const EliminationSet*> eset_set3;
-            for (const auto &c : cset3_candidates) {
-                if constexpr (std::is_same_v<EliminationSet, Column>) {
-                    eset_set3.insert(&mBoard.column(c));
-                } else {
-                    eset_set3.insert(&mBoard.row(c));
-                }
-            }
+            std::set<const EliminationSet*> eset_set3 = esets_of(cset3_candidates);
 
             // Union of all elimination sets
             std::set<const EliminationSet*> eset_total = eset_union;
@@ -210,74 +206,45 @@ bool Analyzer::act_on_swordfish(const Value &value, const CandidateSet &cset1, c
     return did_act;
 }
 
-bool Analyzer::act_on_swordfish() {
+template<class EliminationSet>
+bool Analyzer::act_on_swordfish(const Swordfish &entry) {
+    // The base lines and the elimination lines are always opposite kinds, so
+    // derive one from the other rather than letting a caller pass a mismatched
+    // pair (e.g. <Row, Row>) that would compile and silently misbehave.
+    using CandidateSet = std::conditional_t<std::is_same_v<EliminationSet, Column>, Row, Column>;
+
+    // The three base lines, addressed by their anchor coordinates
+    const CandidateSet &l1 = line_of<CandidateSet>(mBoard, entry.anchors[0]);
+    const CandidateSet &l2 = line_of<CandidateSet>(mBoard, entry.anchors[1]);
+    const CandidateSet &l3 = line_of<CandidateSet>(mBoard, entry.anchors[2]);
+
+    // Collect all elimination lines where candidates appear in the three base lines
+    std::set<const EliminationSet*> elims;
+    for (const auto *line : {&l1, &l2, &l3})
+        for (const auto &c : candidates(*line, entry.value))
+            elims.insert(&line_of<EliminationSet>(mBoard, c));
+
+    // `unit` is fully determined by EliminationSet -- derive it, don't thread it
+    // through as a second source of truth a caller could get wrong.
+    constexpr Unit unit = std::is_same_v<EliminationSet, Column> ? Unit::Column : Unit::Row;
+
     bool did_act = false;
+    for (const auto *e : elims)
+        did_act |= act_on_swordfish(entry.value, l1, l2, l3, *e, unit);
+    return did_act;
+}
 
-    if (mSwordfish.empty()) return did_act;
+bool Analyzer::act_on_swordfish() {
+    if (mSwordfish.empty()) return false;
     assert(mSwordfish.size() == 1);
-
     auto const entry = mSwordfish.back();
 
-    if (entry.is_row_based) {
-        // Row-based Swordfish: the pattern is in three rows, eliminate from columns
-        auto const &row1 = mBoard.row(entry.anchors[0]);
-        auto const &row2 = mBoard.row(entry.anchors[1]);
-        auto const &row3 = mBoard.row(entry.anchors[2]);
-
-        // Collect all columns where candidates appear in these three rows
-        std::set<const Column*> elimination_columns;
-        for (const auto &cell : row1) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_columns.insert(&mBoard.column(cell));
-            }
-        }
-        for (const auto &cell : row2) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_columns.insert(&mBoard.column(cell));
-            }
-        }
-        for (const auto &cell : row3) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_columns.insert(&mBoard.column(cell));
-            }
-        }
-
-        // Eliminate from each column
-        for (const auto* col_ptr : elimination_columns) {
-            did_act |= act_on_swordfish(entry.value, row1, row2, row3, *col_ptr, Unit::Column);
-        }
-    } else {
-        // Column-based Swordfish: the pattern is in three columns, eliminate from rows
-        auto const &col1 = mBoard.column(entry.anchors[0]);
-        auto const &col2 = mBoard.column(entry.anchors[1]);
-        auto const &col3 = mBoard.column(entry.anchors[2]);
-
-        // Collect all rows where candidates appear in these three columns
-        std::set<const Row*> elimination_rows;
-        for (const auto &cell : col1) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_rows.insert(&mBoard.row(cell));
-            }
-        }
-        for (const auto &cell : col2) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_rows.insert(&mBoard.row(cell));
-            }
-        }
-        for (const auto &cell : col3) {
-            if (cell.isNote() && cell.check(entry.value)) {
-                elimination_rows.insert(&mBoard.row(cell));
-            }
-        }
-
-        // Eliminate from each row
-        for (const auto* row_ptr : elimination_rows) {
-            did_act |= act_on_swordfish(entry.value, col1, col2, col3, *row_ptr, Unit::Row);
-        }
-    }
+    // Row-based pattern eliminates from columns; column-based, from rows.
+    bool did_act = entry.is_row_based
+        ? act_on_swordfish<Column>(entry)
+        : act_on_swordfish<Row>(entry);
 
     mSwordfish.clear();
-
     assert(did_act);
     return did_act;
 }

--- a/analyzer-swordfish.cpp
+++ b/analyzer-swordfish.cpp
@@ -2,36 +2,14 @@
 // See LICENSE for details of BSD 3-Clause License
 
 #include "analyzer.h"
+#include "analyzer-util.h"
 #include "board.h"
 #include "verbose.h"
 #include <cassert>
 #include <type_traits>
 
-namespace {
-    // Helper function for Swordfish pattern detection
-    template<class Set>
-    std::vector<Cell> candidates(const Set &set, const Value &value) {
-        std::vector<Cell> candidates;
-
-        for (auto const &cell : set) {
-            if (!cell.isNote()) continue;
-            if (!cell.check(value)) continue;
-
-            candidates.push_back(cell);
-        }
-
-        return candidates;
-    }
-
-    // Map a cell (or coordinate) to the Row or Column it lies on, selecting
-    // which by the Line type parameter. Board exposes both row()/column()
-    // overloads, so one helper serves both find and act, for cells and coords.
-    template<class Line, class CellOrCoord>
-    const Line &line_of(const Board &board, const CellOrCoord &x) {
-        if constexpr (std::is_same_v<Line, Column>) return board.column(x);
-        else                                        return board.row(x);
-    }
-}
+using analyzer_util::candidates;
+using analyzer_util::line_of;
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::find_swordfish(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset,

--- a/analyzer-util.h
+++ b/analyzer-util.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "board.h"
+
+#include <type_traits>
+#include <vector>
+
+// Helpers shared by the fish techniques (X-Wing, Swordfish). Both are pure
+// mappings over the board with no per-technique state, so they live here
+// rather than being copy-pasted into each technique's translation unit. They
+// are wrapped in a named namespace so these collision-prone generic names do
+// not land at global scope for every TU that includes this header.
+namespace analyzer_util {
+
+// The cells of `set` that still hold `value` as a note.
+template<class Set>
+std::vector<Cell> candidates(const Set &set, const Value &value) {
+    std::vector<Cell> candidates;
+
+    for (auto const &cell : set) {
+        if (!cell.isNote()) continue;
+        if (!cell.check(value)) continue;
+
+        candidates.push_back(cell);
+    }
+
+    return candidates;
+}
+
+// The Row or Column (selected by the Line type) that `x` (a Cell or Coord)
+// lies on. Board exposes both row()/column() overloads for Cell and Coord, so
+// one helper serves find and act, for cells and coords, with the row/column
+// choice made once here instead of at every call site.
+template<class Line, class CellOrCoord>
+const Line &line_of(const Board &board, const CellOrCoord &x) {
+    if constexpr (std::is_same_v<Line, Column>) return board.column(x);
+    else                                        return board.row(x);
+}
+
+} // namespace analyzer_util

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -32,14 +32,12 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
     assert(cset.contains(cell));
     assert(eset.contains(cell));
 
-    bool did_find = false;
-
     // are there exactly two candidates for this value on this candidate set?
     auto cset_candidates = candidates(cset, value);
-    if (cset_candidates.size() != 2) return did_find;
+    if (cset_candidates.size() != 2) return false;
 
     // yes! if cell is not the first candidate, we've already considered this cset and found it unsuitable
-    if (cell != cset_candidates[0]) return did_find;
+    if (cell != cset_candidates[0]) return false;
     const Cell& other_cell = cset_candidates[1];
 
     // Get the elimination set for the other cell
@@ -80,23 +78,19 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         assert(mXWings.empty());
         mXWings.push_back(candidate_xwing);
         if (sVerbose) std::cout << "  [fXW] " << candidate_xwing << std::endl;
-        did_find = true;
-        break;
+        return true;
     }
 
-    return did_find;
+    return false;
 }
 
 bool Analyzer::find_xwing(const Cell &cell, const Value &value) {
     assert(cell.isNote());
     assert(cell.check(value));
 
-    bool did_find = false;
-
-    did_find = find_xwing(cell, value, mBoard.row(cell), mBoard.column(cell), mBoard.rows(), true);
-    if (!did_find) did_find = find_xwing(cell, value, mBoard.column(cell), mBoard.row(cell), mBoard.columns(), false);
-
-    return did_find;
+    if (find_xwing(cell, value, mBoard.row(cell), mBoard.column(cell), mBoard.rows(), true))
+        return true;
+    return find_xwing(cell, value, mBoard.column(cell), mBoard.row(cell), mBoard.columns(), false);
 }
 
 bool Analyzer::find_xwings() {

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -2,28 +2,15 @@
 // See LICENSE for details of BSD 3-Clause License
 
 #include "analyzer.h"
+#include "analyzer-util.h"
 #include "board.h"
 #include "verbose.h"
 #include <algorithm>
 #include <cassert>
 #include <type_traits>
 
-namespace {
-    // Helper function for X-Wing pattern detection
-    template<class Set>
-    std::vector<Cell> candidates(const Set &set, const Value &value) {
-        std::vector<Cell> candidates;
-
-        for (auto const &cell : set) {
-            if (!cell.isNote()) continue;
-            if (!cell.check(value)) continue;
-
-            candidates.push_back(cell);
-        }
-
-        return candidates;
-    }
-}
+using analyzer_util::candidates;
+using analyzer_util::line_of;
 
 template<class CandidateSet, class EliminationSet>
 bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset, const std::vector<CandidateSet> &csets, bool by_row) {
@@ -41,13 +28,7 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
     const Cell& other_cell = cset_candidates[1];
 
     // Get the elimination set for the other cell
-    const EliminationSet &other_eset = [&]() -> const EliminationSet& {
-        if constexpr (std::is_same_v<EliminationSet, Column>) {
-            return mBoard.column(other_cell);
-        } else {
-            return mBoard.row(other_cell);
-        }
-    }();
+    const EliminationSet &other_eset = line_of<EliminationSet>(mBoard, other_cell);
     assert(eset < other_eset);
 
     // yes! for every subsequent cset
@@ -133,38 +114,40 @@ bool Analyzer::act_on_xwing(const Value &value, const CandidateSet &cset1, const
     return did_act;
 }
 
-bool Analyzer::act_on_xwing() {
+template<class EliminationSet>
+bool Analyzer::act_on_xwing(const XWing &entry) {
+    // The base lines and the elimination lines are always opposite kinds, so
+    // derive one from the other rather than letting a caller pass a mismatched
+    // pair (e.g. <Row, Row>) that would compile and silently misbehave.
+    using CandidateSet = std::conditional_t<std::is_same_v<EliminationSet, Column>, Row, Column>;
+
+    // The two base lines hold the pattern; the two elimination lines are where
+    // strays for `value` get cleared. line_of picks row vs column once.
+    auto anchor_candidates   = candidates(line_of<CandidateSet>(mBoard, entry.anchor),   entry.value);
+    auto diagonal_candidates = candidates(line_of<CandidateSet>(mBoard, entry.diagonal), entry.value);
+    auto anchor_eliminates   = candidates(line_of<EliminationSet>(mBoard, entry.anchor),   entry.value);
+    auto diagonal_eliminates = candidates(line_of<EliminationSet>(mBoard, entry.diagonal), entry.value);
+
+    // `unit` is fully determined by EliminationSet -- derive it, don't thread it.
+    constexpr Unit unit = std::is_same_v<EliminationSet, Column> ? Unit::Column : Unit::Row;
+
     bool did_act = false;
+    did_act |= act_on_xwing(entry.value, anchor_candidates, diagonal_candidates, anchor_eliminates, unit);
+    did_act |= act_on_xwing(entry.value, anchor_candidates, diagonal_candidates, diagonal_eliminates, unit);
+    return did_act;
+}
 
-    if (mXWings.empty()) return did_act;
+bool Analyzer::act_on_xwing() {
+    if (mXWings.empty()) return false;
     assert(mXWings.size() == 1);
-
     auto const entry = mXWings.back();
-    if (entry.is_row_based) {
-        // Row-based X-Wing: eliminate candidates from the two columns
-        auto anchor_row_candidates = candidates(mBoard.row(entry.anchor), entry.value);
-        auto diagonal_row_candidates = candidates(mBoard.row(entry.diagonal), entry.value);
-        auto anchor_column_eliminates = candidates(mBoard.column(entry.anchor), entry.value);
-        auto diagonal_column_eliminates = candidates(mBoard.column(entry.diagonal), entry.value);
 
-        did_act |= act_on_xwing(entry.value, anchor_row_candidates, diagonal_row_candidates,
-                                           anchor_column_eliminates, Unit::Column);
-        did_act |= act_on_xwing(entry.value, anchor_row_candidates, diagonal_row_candidates,
-                                           diagonal_column_eliminates, Unit::Column);
-    } else {
-        // Column-based X-Wing: eliminate candidates from the two rows
-        auto anchor_column_candidates = candidates(mBoard.column(entry.anchor), entry.value);
-        auto diagonal_column_candidates = candidates(mBoard.column(entry.diagonal), entry.value);
-        auto anchor_row_eliminates = candidates(mBoard.row(entry.anchor), entry.value);
-        auto diagonal_row_eliminates = candidates(mBoard.row(entry.diagonal), entry.value);
+    // Row-based pattern eliminates from columns; column-based, from rows.
+    bool did_act = entry.is_row_based
+        ? act_on_xwing<Column>(entry)
+        : act_on_xwing<Row>(entry);
 
-        did_act |= act_on_xwing(entry.value, anchor_column_candidates, diagonal_column_candidates,
-                                           anchor_row_eliminates, Unit::Row);
-        did_act |= act_on_xwing(entry.value, anchor_column_candidates, diagonal_column_candidates,
-                                           diagonal_row_eliminates, Unit::Row);
-    }
     mXWings.clear();
-
     assert(did_act);
     return did_act;
 }

--- a/analyzer.h
+++ b/analyzer.h
@@ -180,6 +180,8 @@ private:
     template<class CandidateSet, class EliminationSet>
     bool act_on_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
                                           const EliminationSet &eset, Unit unit);
+    template<class EliminationSet>
+    bool act_on_xwing(const XWing &entry);
     bool act_on_xwing();
 
 private:

--- a/analyzer.h
+++ b/analyzer.h
@@ -204,6 +204,8 @@ private:
     template<class CandidateSet, class EliminationSet>
     bool act_on_swordfish(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2, const CandidateSet &cset3,
                                               const EliminationSet &eset, Unit unit);
+    template<class EliminationSet>
+    bool act_on_swordfish(const Swordfish &entry);
     bool act_on_swordfish();
 
 private:

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -200,6 +200,52 @@ void test_swordfish_column_based() {
           "all six pattern cells kept candidate 8");
 }
 
+// A row-based Swordfish on value 8 -- the transpose of the column-based case
+// above. The act side reaches the row-based branch (eliminate from columns)
+// only here in the whitebox tests; the integration suite drives it, but this
+// locks it in as a regression guard.
+//
+//        c0 c1 c2
+//   r0    8  8  .
+//   r1    .  8  8
+//   r2    8  .  8
+//   r4    8  .  .      <- (4,0) is outside the base rows
+//   r5    .  8  .      <- (5,1) is outside the base rows
+//
+// Base rows {0,1,2}, each with two 8s; their columns union to exactly {0,1,2}.
+// So 8 in those columns occupies the three base rows, and the strays at (4,0)
+// and (5,1) are eliminable. As with the column-based case, every cover column
+// holds exactly three 8s (two in the pattern, one outside): a tight cover line.
+void test_swordfish_row_based() {
+    std::cout << "[swordfish] row-based detection and action (eliminate from columns)\n";
+    Board board = empty_board();
+    const Value V = kEight;
+    confine_value(board, V, {
+        {0,0},{0,1},        // row 0: columns {0,1}
+        {1,1},{1,2},        // row 1: columns {1,2}
+        {2,0},{2,2},        // row 2: columns {0,2}
+        {4,0},{5,1},        // strays to be eliminated
+    });
+
+    Analyzer analyzer(board);
+    bool found = AnalyzerTest::find_swordfish(analyzer, cell_at(board, 0, 0), V);
+    check(found, "row Swordfish detected on a position with only tight cover lines");
+    check(AnalyzerTest::swordfish_count(analyzer) == 1, "exactly one Swordfish recorded");
+    if (AnalyzerTest::swordfish_count(analyzer) == 1) {
+        check(AnalyzerTest::swordfish_row_based(analyzer), "recorded Swordfish is row-based");
+        check(AnalyzerTest::swordfish_value(analyzer) == V, "recorded Swordfish is for value 8");
+    }
+
+    bool acted = AnalyzerTest::act_on_swordfish(analyzer);
+    check(acted, "act_on_swordfish reports an elimination");
+    check(!has_candidate(board, 4, 0, V), "stray 8 at (4,0) eliminated");
+    check(!has_candidate(board, 5, 1, V), "stray 8 at (5,1) eliminated");
+    check(has_candidate(board, 0, 0, V) && has_candidate(board, 0, 1, V)
+       && has_candidate(board, 1, 1, V) && has_candidate(board, 1, 2, V)
+       && has_candidate(board, 2, 0, V) && has_candidate(board, 2, 2, V),
+          "all six pattern cells kept candidate 8");
+}
+
 // Same base columns, strays removed: a Swordfish shape with nothing to
 // eliminate must not be recorded (recording it would assert in act).
 void test_swordfish_no_elimination() {
@@ -668,6 +714,7 @@ void test_colorchain_benign_not_actionable() {
 
 int main() {
     test_swordfish_column_based();
+    test_swordfish_row_based();
     test_swordfish_no_elimination();
     test_xychain_detect_and_act();
     test_xychain_best_selection();


### PR DESCRIPTION
Closes #32.

Three commits:

**1. Swordfish: de-duplicate the triplicated elimination-set collection.**
The `if constexpr (is_same_v<…, Column>) → board.column() else board.row()` dispatch appeared in six hand-rolled collection loops; collapsed to a single `line_of<Line>(Board&, x)` helper. Find side: three identical set builders → one `esets_of` lambda. Act side: six collection-loop copies → a templated `act_on_swordfish<EliminationSet>(const Swordfish&)` helper dispatching once on `is_row_based`, with `CandidateSet` and `Unit` both derived from the single `EliminationSet` param (no mismatched `<Row, Row>` possible). Added `test_swordfish_row_based` (transpose of the column-based test) to guard the row-based act branch the unit suite previously didn't reach.

**2. X-Wing/Swordfish: drop the `did_find` break-flag from the find workers.**
Finishes what #29 started — replaced the break-flag with early return in both fish' templated workers and per-value dispatchers. Out of scope: the `did_find` accumulators elsewhere (those are "found ≥1" counters, not break-signals).

**3. X-Wing/Swordfish: promote the row/column dispatch to a shared helper.**
Honors the twin rule: commit 1 centralized `line_of` but left it in swordfish.cpp's anonymous namespace, so X-Wing still hand-rolled the identical idiom (an IIFE switch in find, a runtime if/else in act). Promoted both helpers the fish were duplicating — `line_of` and `candidates` (the latter was copy-pasted verbatim into both TUs) — into a shared `analyzer-util.h`, and routed both twins through them: `find_xwing`'s IIFE → one `line_of` call; `act_on_xwing` templatized on `EliminationSet` exactly like `act_on_swordfish`. The row/column switch now lives in exactly one place for both techniques.

## Verification
- `make` clean under `-Wall -Werror` (local clang).
- `make unit` + `make test`: all pass (unit + 80 integration). The rewritten `act_on_xwing` is covered on both branches by the existing `test_xwing_row_based` / `test_xwing_column_based`; `act_on_swordfish` by `test_swordfish_column_based` / the new `test_swordfish_row_based`.
- Byte-identical verbose output vs `main` on both fish: Swordfish row-based (`P_sf`) + column-based (`P_hard`), X-Wing (`P_clm`). `[f?SF]`/`[f?XW]` traces diff clean, re-verified after each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)