### PR TITLE
Technique registry: scaffolding + port Naked Singles (#7)

### DIFF
--- a/analyzer-nakedsingles.cpp
+++ b/analyzer-nakedsingles.cpp
@@ -1,56 +1,55 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-nakedsingles.h"
 #include "board.h"
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
 
-#include <algorithm>
+#include <memory>
 
-bool Analyzer::test_naked_single(const Cell &cell) const {
-    return cell.isNote()
-        && cell.notes().count() == 1;
-}
+namespace {
+// File-local: Naked Singles has no whitebox hooks, so nothing outside this TU
+// needs to name or downcast the finding. print() emits the same bytes the old
+// free operator<<(ostream, Analyzer::NakedSingle) did: "coord#value".
+struct NakedSingleFinding : Finding {
+    Coord coord;
+    Value value;
+    NakedSingleFinding(const Coord &c, const Value &v) : coord(c), value(v) { }
+    void print(std::ostream &o) const override { o << coord << "#" << value; }
+};
+} // namespace
 
-bool Analyzer::find_naked_singles() {
-    // https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#scanning
-    // A naked single arises when there is only one possible candidate for a cell
+// A naked single arises when there is only one possible candidate for a cell.
+// https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#scanning
+bool NakedSingleTechnique::find(const Board &board, FindingList &out) const {
     bool did_find = false;
 
-    for (auto const &cell: mBoard.cells()) {
+    for (auto const &cell : board.cells()) {
         // is this a naked single?
-        if (!test_naked_single(cell)) continue;
+        if (!cell.isNote() || cell.notes().count() != 1) continue;
 
-        assert(std::find_if(mNakedSingles.begin(), mNakedSingles.end(),
-                   [cell](const auto &entry) { return cell.coord() == entry.coord; }) == mNakedSingles.end());
-
-        // yes! let's record it
-        NakedSingle ns(cell.coord(), cell.notes().values().at(0));
-        mNakedSingles.push_back(ns);
-        if (sVerbose) std::cout << "  [fNS] " << ns << std::endl;
+        // yes! let's record it. (No duplicate-coord assert: the bucket is
+        // cleared each analyze() and every cell has a distinct coord.)
+        auto finding = std::make_shared<NakedSingleFinding>(cell.coord(), cell.notes().values().at(0));
+        if (sVerbose) std::cout << "  [fNS] " << finding->coord << "#" << finding->value << std::endl;
+        out.push_back(std::move(finding));
         did_find = true;
     }
 
     return did_find;
 }
 
-bool Analyzer::act_on_naked_single() {
-    bool did_act = false;
-
-    if (mNakedSingles.empty()) return did_act;
+bool NakedSingleTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
 
     // singles can be acted on all at once
-    for (auto const &entry: mNakedSingles) {
-        std::cout << "[NS] " << entry.coord << " =" << entry.value << std::endl;
-        mBoard.set_value_at(entry.coord, entry.value);
-        did_act = true;
+    for (auto const &f : mine) {
+        auto const *ns = static_cast<const NakedSingleFinding *>(f.get());
+        std::cout << "[NS] " << ns->coord << " =" << ns->value << std::endl;
+        board.set_value_at(ns->coord, ns->value);
     }
-    mNakedSingles.clear();
-
-    assert(did_act);
-    return did_act;
-}
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::NakedSingle &ns) {
-    return outs << ns.coord << "#" << ns.value;
+    mine.clear();
+    return true;
 }

--- a/analyzer-nakedsingles.cpp
+++ b/analyzer-nakedsingles.cpp
@@ -33,7 +33,7 @@ bool NakedSingleTechnique::find(const Board &board, FindingList &out) const {
         // yes! let's record it. (No duplicate-coord assert: the bucket is
         // cleared each analyze() and every cell has a distinct coord.)
         auto finding = std::make_shared<NakedSingleFinding>(cell.coord(), cell.notes().values().at(0));
-        if (sVerbose) std::cout << "  [fNS] " << finding->coord << "#" << finding->value << std::endl;
+        if (sVerbose) { std::cout << "  [fNS] "; finding->print(std::cout); std::cout << std::endl; }
         out.push_back(std::move(finding));
         did_find = true;
     }

--- a/analyzer-nakedsingles.cpp
+++ b/analyzer-nakedsingles.cpp
@@ -7,6 +7,7 @@
 #include "coord.h"
 #include "verbose.h"
 
+#include <cassert>
 #include <memory>
 
 namespace {
@@ -46,6 +47,13 @@ bool NakedSingleTechnique::apply(Board &board, FindingList &mine) const {
 
     // singles can be acted on all at once
     for (auto const &f : mine) {
+        // Bucket invariant: analyze() routes reg[i]->find() into mFindings[i],
+        // so this bucket only ever holds this technique's own findings -- which
+        // is what makes the static_cast sound. Nothing but discipline enforces
+        // that, and this line is the template every ported apply() copies, so
+        // assert the contract to turn a wrong-bucket wiring bug into a caught
+        // error instead of UB.
+        assert(dynamic_cast<const NakedSingleFinding *>(f.get()));
         auto const *ns = static_cast<const NakedSingleFinding *>(f.get());
         std::cout << "[NS] " << ns->coord << " =" << ns->value << std::endl;
         board.set_value_at(ns->coord, ns->value);

--- a/analyzer-nakedsingles.h
+++ b/analyzer-nakedsingles.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+
+// Naked single: a note cell with exactly one remaining candidate. NS has no
+// whitebox hooks, so the concrete NakedSingleFinding lives file-local in the
+// .cpp; only the technique class needs to be nameable here (registry()
+// constructs it directly).
+class NakedSingleTechnique : public Technique {
+public:
+    const char *tag()  const override { return "NS"; }
+    Tier        tier() const override { return Tier::Single; }
+    bool  brace_each() const override { return false; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -99,6 +99,11 @@ void Analyzer::analyze() {
     // reproduce the exact cascade order (a correctness precondition -- see the
     // guard in registry()). Each technique finds into its own bucket.
     const auto &reg = registry();
+    // mFindings is indexed in lockstep with reg (bucket i belongs to reg[i]);
+    // the two are sized together at construction. Assert it here rather than
+    // trust it: this positional coupling is the invariant that replaced the ten
+    // hand-synchronized init sites, so it gets the same executable guard.
+    assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
     if (!did_find) did_find = find_hidden_singles();
@@ -118,6 +123,7 @@ bool Analyzer::act(const bool singles_only) {
     // Registry prefix (cascade order). Single-tier techniques always run;
     // Advanced ones are skipped under singles_only, mirroring the suffix gate.
     const auto &reg = registry();
+    assert(mFindings.size() == reg.size());  // lockstep index; see analyze()
     for (size_t i = 0; i < reg.size() && !did_act; ++i) {
         if (reg[i]->tier() == Tier::Advanced && singles_only) continue;
         did_act = reg[i]->apply(mBoard, mFindings[i]);
@@ -180,6 +186,7 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     // is shared via print_section_core. Safe to always trail with endl while
     // the suffix below is non-empty; the final port must reshape this.
     const auto &reg = Analyzer::registry();
+    assert(a.mFindings.size() == reg.size());  // lockstep index; see analyze()
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -10,15 +10,32 @@
 #include "cell.h"
 #include "verbose.h"
 
+#include <cassert>
+#include <iterator>
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 
 // The stateless techniques, built once and shared by every Analyzer. Grows one
 // entry per port (cascade order); PR 1 holds only Naked Singles.
 const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
+    // Canonical cascade order for the whole issue-#7 series. The registry must
+    // always be a strict in-order PREFIX of this list: analyze()/act() run the
+    // registry ahead of the hand-written suffix, so a technique ported out of
+    // order would silently reorder application and change solver behavior. That
+    // makes cascade order a correctness *precondition* for every PR in the
+    // series, not a style convention -- the guard below makes it executable.
+    // (It checks the registry side; the suffix stays hand-ordered source that
+    // each port shortens by one, and remains a reviewer obligation.)
+    [[maybe_unused]] static constexpr const char *kCascade[] = {
+        "NS", "HS", "NP", "LC", "HP", "XW", "SC", "YW", "SF", "XY",
+    };
     static const std::vector<std::unique_ptr<Technique>> reg = [] {
         std::vector<std::unique_ptr<Technique>> r;
         r.push_back(std::make_unique<NakedSingleTechnique>());
+        assert(r.size() <= std::size(kCascade));
+        for (size_t i = 0; i < r.size(); ++i)
+            assert(std::string_view(r[i]->tag()) == kCascade[i]);
         return r;
     }();
     return reg;
@@ -78,7 +95,9 @@ void Analyzer::analyze() {
     mXYChains.clear();
 
     bool did_find = false;
-    // Registry prefix (cascade order): each technique finds into its own bucket.
+    // Registry prefix, then the hand-written suffix below: the two must together
+    // reproduce the exact cascade order (a correctness precondition -- see the
+    // guard in registry()). Each technique finds into its own bucket.
     const auto &reg = registry();
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -2,6 +2,7 @@
 // See LICENSE for details of BSD 3-Clause License
 
 #include "analyzer.h"
+#include "techniques.h"
 #include "board.h"
 #include "row.h"
 #include "column.h"
@@ -9,7 +10,19 @@
 #include "cell.h"
 #include "verbose.h"
 
+#include <memory>
 #include <stdexcept>
+
+// The stateless techniques, built once and shared by every Analyzer. Grows one
+// entry per port (cascade order); PR 1 holds only Naked Singles.
+const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
+    static const std::vector<std::unique_ptr<Technique>> reg = [] {
+        std::vector<std::unique_ptr<Technique>> r;
+        r.push_back(std::make_unique<NakedSingleTechnique>());
+        return r;
+    }();
+    return reg;
+}
 
 template<class Set>
 void Analyzer::filter_notes(Cell &cell, const Set &set) {
@@ -53,7 +66,7 @@ void Analyzer::filter_notes() {
 void Analyzer::analyze() {
     filter_notes();
 
-    mNakedSingles.clear();
+    for (auto &b : mFindings) b.clear();
     mHiddenSingles.clear();
     mNakedPairs.clear();
     mLockedCandidates.clear();
@@ -65,7 +78,10 @@ void Analyzer::analyze() {
     mXYChains.clear();
 
     bool did_find = false;
-    did_find = find_naked_singles();
+    // Registry prefix (cascade order): each technique finds into its own bucket.
+    const auto &reg = registry();
+    for (size_t i = 0; i < reg.size() && !did_find; ++i)
+        did_find = reg[i]->find(mBoard, mFindings[i]);
     if (!did_find) did_find = find_hidden_singles();
     if (!did_find) did_find = find_naked_pairs();
     if (!did_find) did_find = find_locked_candidates();
@@ -80,7 +96,13 @@ void Analyzer::analyze() {
 bool Analyzer::act(const bool singles_only) {
     bool did_act = false;
 
-    did_act = act_on_naked_single();
+    // Registry prefix (cascade order). Single-tier techniques always run;
+    // Advanced ones are skipped under singles_only, mirroring the suffix gate.
+    const auto &reg = registry();
+    for (size_t i = 0; i < reg.size() && !did_act; ++i) {
+        if (reg[i]->tier() == Tier::Advanced && singles_only) continue;
+        did_act = reg[i]->apply(mBoard, mFindings[i]);
+    }
     if (!did_act) did_act = act_on_hidden_single();
 
     if (!singles_only) {
@@ -100,24 +122,48 @@ bool Analyzer::act(const bool singles_only) {
 namespace {
 // Render one "[TAG](count) {e1, e2, ...}" line of the analyzer dump. The
 // singles print their elements bare; every other technique wraps each element
-// in its own braces. Factored out of operator<< so the nine sections share a
-// single definition instead of nine copies of the is_first comma dance.
-template<class Container>
-void print_section(std::ostream &outs, const char *tag, const Container &items, bool brace_each) {
+// in its own braces. All framing (tag, count, separators, per-item braces)
+// lives here so the registry-prefix and hand-written-suffix sections share
+// every byte; each caller supplies only how to render one item.
+template<class Container, class Render>
+void print_section_core(std::ostream &outs, const char *tag, const Container &items,
+                        bool brace_each, Render render) {
     outs << "[" << tag << "](" << items.size() << ") {";
     bool is_first = true;
     for (auto const &item : items) {
         if (!is_first) { outs << ", "; }
         is_first = false;
-        if (brace_each) { outs << "{" << item << "}"; }
-        else            { outs << item; }
+        if (brace_each) { outs << "{"; render(outs, item); outs << "}"; }
+        else            {              render(outs, item);              }
     }
     outs << "}";
+}
+
+// Suffix path (not-yet-ported techniques): render each element via its own
+// operator<<.
+template<class Container>
+void print_section(std::ostream &outs, const char *tag, const Container &items, bool brace_each) {
+    print_section_core(outs, tag, items, brace_each,
+        [](std::ostream &o, auto const &item) { o << item; });
+}
+
+// Registry path (ported techniques): render each type-erased finding via
+// Finding::print. Tag and brace flag come from the technique itself.
+void print_section(std::ostream &outs, const Technique &tech, const FindingList &findings) {
+    print_section_core(outs, tech.tag(), findings, tech.brace_each(),
+        [](std::ostream &o, auto const &f) { f->print(o); });
 }
 } // namespace
 
 std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
-    print_section(outs, "NS", a.mNakedSingles,     false); outs << std::endl;
+    // Registry prefix (cascade order), each line followed by endl -- byte-for-
+    // byte identical to the hand-written lines it replaces because all framing
+    // is shared via print_section_core. Safe to always trail with endl while
+    // the suffix below is non-empty; the final port must reshape this.
+    const auto &reg = Analyzer::registry();
+    for (size_t i = 0; i < reg.size(); ++i) {
+        print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
+    }
     print_section(outs, "HS", a.mHiddenSingles,    false); outs << std::endl;
     print_section(outs, "NP", a.mNakedPairs,       true);  outs << std::endl;
     print_section(outs, "LC", a.mLockedCandidates, true);  outs << std::endl;

--- a/analyzer.h
+++ b/analyzer.h
@@ -4,6 +4,7 @@
 
 #include "cell.h"
 #include "board.h"
+#include "technique.h"
 
 #include <unordered_set>
 #include <set>
@@ -13,10 +14,10 @@
 
 class Analyzer {
 public:
-    Analyzer(Board &board) : mBoard(board) { }
+    Analyzer(Board &board) : mFindings(registry().size()), mBoard(board) { }
 
     Analyzer(Board &board, Analyzer const &other)
-        : mNakedSingles(other.mNakedSingles)
+        : mFindings(other.mFindings)
         , mHiddenSingles(other.mHiddenSingles)
         , mNakedPairs(other.mNakedPairs)
         , mLockedCandidates(other.mLockedCandidates)
@@ -57,20 +58,21 @@ private:
     void filter_notes();
 
 private:
-    //** naked singles
-    struct NakedSingle {
-        Coord coord;
-        Value value;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const NakedSingle &);
-    std::vector<NakedSingle> mNakedSingles;
+    //** technique registry
+    // The solving techniques, constructed once and shared by every Analyzer.
+    // Function-local static (defined in analyzer.cpp): built on first use, and
+    // -- crucially -- never copied per state, so forgetting to copy a technique
+    // in the rebinding ctor is no longer possible (issue #7). Private: analyze()/
+    // act()/operator<</AnalyzerTest all reach it via membership or friendship.
+    static const std::vector<std::unique_ptr<Technique>> &registry();
 
-    // find
-    bool test_naked_single(const Cell &) const;
-    bool find_naked_singles();
-
-    // act
-    bool act_on_naked_single();
+    // Per-state findings, one bucket per registry() technique, indexed parallel
+    // to it. The sole member still carried forward across the state copy (see
+    // issue #7 lifecycle decision). Declared before every other technique member
+    // and before mBoard so the rebinding ctor's init list is legal under
+    // -Wreorder; the rebinding-ctor regression test guards the one hand-written
+    // mFindings(other.mFindings) copy.
+    std::vector<FindingList> mFindings;
 
 private:
     //** hidden singles

--- a/technique.h
+++ b/technique.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "board.h"
+
+#include <memory>
+#include <vector>
+#include <iostream>
+
+// Tier drives the singles_only gate in act(): Single techniques always run,
+// Advanced ones only when singles_only is false.
+enum class Tier { Single, Advanced };
+
+// Type-erased finding. Concrete subtypes live either in the technique's .cpp
+// (hook-free techniques) or in a shared header (hooked techniques -- see the
+// test-seam contract). Only the owning technique downcasts its own bucket.
+struct Finding {
+    virtual ~Finding() = default;
+    virtual void print(std::ostream &) const = 0;
+};
+
+// shared_ptr<const> => per-state copy of mFindings is a shallow vector copy,
+// no clone() ladder, no slicing (findings are immutable once found).
+using FindingList = std::vector<std::shared_ptr<const Finding>>;
+
+class Technique {
+public:
+    virtual ~Technique() = default;
+    virtual const char *tag()  const = 0;   // "NS", "HS", ...
+    virtual Tier        tier() const = 0;
+    virtual bool        brace_each() const = 0;  // print_section wrap flag
+
+    // Find every occurrence on the board; append to `out`. Return whether any
+    // were found. const in the Board: find is a pure query.
+    virtual bool find(const Board &, FindingList &out) const = 0;
+
+    // Apply this technique's findings to the board; consume (clear) them.
+    virtual bool apply(Board &, FindingList &mine) const = 0;
+};

--- a/techniques.h
+++ b/techniques.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+// Thin aggregator: pulls in every concrete Technique subclass so that
+// Analyzer::registry() (in analyzer.cpp) can construct each one directly.
+// One #include is added here per technique as it ports (cascade order).
+
+#include "analyzer-nakedsingles.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <set>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -44,6 +45,24 @@ struct XYSpec {
 
 // Friend hook: the only thing allowed to read/construct Analyzer internals.
 struct AnalyzerTest {
+    // --- rebinding ctor / carried findings (issue #7) ---
+    // These reach the single per-state member that survives the state copy, so
+    // the regression test can prove the rebinding ctor carries it forward
+    // without naming any (file-local) concrete Finding subtype: it downcasts
+    // nothing and compares via Finding::print instead.
+    static size_t findings_bucket_count(const Analyzer &a) { return a.mFindings.size(); }
+    static size_t findings_total(const Analyzer &a) {
+        size_t n = 0;
+        for (auto const &bucket : a.mFindings) n += bucket.size();
+        return n;
+    }
+    static std::string findings_render(const Analyzer &a) {
+        std::ostringstream os;
+        for (auto const &bucket : a.mFindings)
+            for (auto const &f : bucket) { f->print(os); os << ";"; }
+        return os.str();
+    }
+
     // --- swordfish ---
     static bool   find_swordfish(Analyzer &a, const Cell &c, const Value &v) { return a.find_swordfish(c, v); }
     static bool   act_on_swordfish(Analyzer &a)                              { return a.act_on_swordfish(); }
@@ -710,6 +729,44 @@ void test_colorchain_benign_not_actionable() {
           "test_color_chain reports a benign chain as not actionable");
 }
 
+// ===========================================================================
+// Rebinding ctor (issue #7)
+// ===========================================================================
+//
+// The migration to the technique registry collapses the ten hand-copied result
+// vectors into one carried member, mFindings, initialized by a single
+// hand-written line in the rebinding ctor (`mFindings(other.mFindings)`). Drop
+// that line and *every* ported technique silently stops carrying forward. This
+// test isolates exactly that line: it builds an analyzer with a known finding,
+// then constructs a second analyzer through the rebinding ctor ONLY (never
+// calling analyze() on it), so the copied member is the sole possible source of
+// its findings. Removing the initializer turns this into a named failure rather
+// than a mysterious integration hang.
+void test_rebinding_ctor_carries_findings() {
+    std::cout << "[rebinding ctor] carries mFindings forward across the state copy (issue #7)\n";
+
+    // A single note cell pinned to one candidate is a naked single; every other
+    // cell still carries all nine, so analyze() records exactly one finding.
+    Board board = empty_board();
+    set_candidates(board, 0, 0, {5});
+
+    Analyzer a(board);
+    a.analyze();
+    check(AnalyzerTest::findings_bucket_count(a) == 1, "one registry bucket (NS only, PR 1)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket");
+
+    // Copy the candidate grid and rebind onto it -- this is the ONLY operation
+    // under test. b.analyze() is deliberately never called.
+    Board board2(board);
+    Analyzer b(board2, a);
+    check(AnalyzerTest::findings_bucket_count(b) == AnalyzerTest::findings_bucket_count(a),
+          "rebinding ctor preserves the bucket count");
+    check(AnalyzerTest::findings_total(b) == AnalyzerTest::findings_total(a),
+          "rebinding ctor carries the findings forward (drop mFindings(other.mFindings) => this fails)");
+    check(AnalyzerTest::findings_render(b) == AnalyzerTest::findings_render(a),
+          "the carried findings are byte-identical to the source's");
+}
+
 } // namespace
 
 int main() {
@@ -730,6 +787,7 @@ int main() {
     test_xwing_anchor_not_first();
     test_colorchain_rule2_contradiction();
     test_colorchain_benign_not_actionable();
+    test_rebinding_ctor_carries_findings();
 
     std::cout << "----------------------------------------\n";
     if (failures == 0) { std::cout << "unit: all checks passed\n"; return 0; }


### PR DESCRIPTION
**PR 1 of the issue #7 series** (targets the `issue-7` integration branch, not `main`). Stands up the technique-registry machinery and ports the first technique end-to-end; the remaining nine port one-per-PR in cascade order (NS → HS → NP → LC → HP → XW → SC → YW → SF → XY).

## What this does

Models a solving technique as one object instead of the ~8 hand-synchronized edit sites it is today (struct, member vector, find/test/act decls, the `analyze()`/`act()` cascades, `operator<<`, the rebinding copy ctor, the `clear()` block). The prize is the rebinding ctor at `analyzer.h`: forget an initializer and the member is default-constructed empty in every state copy, so the technique silently never fires.

**Design:** stateless `Technique` objects in a single shared `registry()` (never copied → the ten technique members stop being copied at all), plus one carried per-state `mFindings` member (a bucket per registry entry).

### New (header-only, no Makefile change)
- `technique.h` — `Tier`, `Finding` + `FindingList`, the abstract `Technique` interface (`tag`/`tier`/`brace_each`/`find`/`apply`).
- `analyzer-nakedsingles.h` — declares `NakedSingleTechnique`.
- `techniques.h` — thin aggregator; grows one `#include` per port.

### Modified
- `analyzer.{h,cpp}` — `registry()` function-local static; `mFindings` (declared ahead of `mBoard` for `-Wreorder`); registry-prefix loops in `analyze()`/`act()` (tier-gated) ahead of the unchanged suffix; `operator<<` refactored to a shared `print_section_core` behind two `print_section` overloads.
- `analyzer-nakedsingles.cpp` — rewritten to `NakedSingleTechnique::find`/`apply` with a file-local `NakedSingleFinding`; `[fNS]`/`[NS]` output reproduced byte-for-byte.
- `tests/unit/test_analyzer.cpp` — `test_rebinding_ctor_carries_findings`.

## On site 7: reduced, not eliminated

This collapses the ten carried result vectors into one `mFindings`, so the hazard drops from **ten silent initializers to one loud line** (`mFindings(other.mFindings)`). It is **not** eliminated: `Analyzer` still holds `Board &mBoard`, which is the sole reason a hand-written rebinding ctor is mandatory. True elimination ("drop the `Board&` member") is a separate, out-of-scope follow-up. The one residual line is guarded by a dedicated regression test.

## Verification

| Check | Result |
|---|---|
| `make` (`-Wall -Werror`) | clean |
| `make test` (black-box REPL) | **80/80** |
| `make unit` (whitebox) | all pass, incl. the new rebinding-ctor test |
| Byte-for-byte step transcript vs pre-PR `main` | **identical across all 7 `run.sh` fixtures** |
| Mutation check: drop `mFindings(other.mFindings)` | test fails with 3 named checks |

The refactor is behavior-preserving; the whole-branch head-to-head diff against `main` is the exhaustive backstop at series end.

## Note

`Coord` has no default constructor, so `NakedSingleFinding` couldn't be default-constructed for `make_shared<>()`; it gets a 2-arg ctor and is constructed in place. Local, no interface impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)