### PR TITLE
CI: gate PRs targeting the issue-7 integration branch (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # issue-7 is the technique-registry integration branch: nine more ports land
+  # on it one PR at a time before it merges to main. Gate each of those PRs so a
+  # Linux gcc/libstdc++ break is caught per-port, not bisected across ten squash
+  # commits at series end. Remove this entry when issue-7 merges and is deleted.
   pull_request:
-    branches: [main]
+    branches: [main, issue-7]
 
 jobs:
   build:


### PR DESCRIPTION
Adds `issue-7` to the CI workflow's `pull_request` base-branch filter so every remaining technique-registry port (nine more, one PR at a time) is gated by the toolchain matrix before it lands, instead of a Linux gcc/libstdc++ break hiding until the `issue-7` → `main` PR and needing to be bisected across ten squash commits.

## Change
```yaml
  pull_request:
    branches: [main, issue-7]
```
One line under the existing `pull_request` trigger. `push:` is left as `[main]` on purpose: the `pull_request` trigger already covers each port, and adding `issue-7` to `push:` would only re-run CI redundantly on merge.

## Notes
- **Temporary by design.** `issue-7` is deleted once the series lands on `main`, at which point this entry is dead config. It should be removed in the final series PR (a reminder comment is inline in the workflow).
- **This PR itself won't trigger CI.** For `pull_request` events GitHub reads the trigger config from the base branch, and `issue-7` doesn't yet contain the filter. There's nothing to run on a YAML-only change anyway; the gate takes effect for the *next* PR into `issue-7`.
- Does not change what CI runs, only when. The matrix (Linux gcc/libstdc++, clang, macOS libc++) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)