### PR TITLE
Technique registry: port Naked Pairs (#7)

### DIFF
--- a/analyzer-nakedpairs.cpp
+++ b/analyzer-nakedpairs.cpp
@@ -1,13 +1,35 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-nakedpairs.h"
 #include "board.h"
+#include "row.h"  // Row: the explicit test_naked_pair instantiation at file end
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
 
-#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <utility>
 
-namespace { // anon
+namespace {
+// File-local: NP's whitebox hook tests the predicate, not the finding, so nothing
+// outside this TU needs to name or downcast NakedPairFinding. print() emits the
+// same bytes the old free operator<<(ostream, Analyzer::NakedPair) did:
+// "{coord1,coord2}#{value1,value2}".
+struct NakedPairFinding : Finding {
+    std::pair<Coord, Coord> coords;
+    std::pair<Value, Value> values;
+    NakedPairFinding(std::pair<Coord, Coord> c, std::pair<Value, Value> v) : coords(c), values(v) { }
+    bool same(const NakedPairFinding &o) const { return coords == o.coords && values == o.values; }
+    void print(std::ostream &o) const override {
+        o << "{" << coords.first << "," << coords.second << "}#{" << values.first << "," << values.second << "}";
+    }
+};
+
+// Would acting on the pair (c1, c2) with values (v1, v2) actually eliminate a
+// candidate somewhere in `set`? Was the anon-namespace helper of the same name;
+// unchanged by the port.
 template<class Set>
 bool would_act(const Set &set, const Cell &c1, const Cell &c2, const Value &v1, const Value &v2) {
     bool would_act = false;
@@ -25,10 +47,77 @@ bool would_act(const Set &set, const Cell &c1, const Cell &c2, const Value &v1, 
     }
     return would_act;
 }
+
+// Find a naked pair for `cell` within `set`, if any, appending it to `out`. Was
+// Analyzer::find_naked_pair; the member vector dedup is now a scan of `out`
+// (this technique's own bucket, so every entry downcasts to NakedPairFinding).
+template<class Set>
+bool find_naked_pair(const Cell &cell, const Set &set, FindingList &out) {
+    // cell is fixed across the loop, so its candidate pair is too; enumerate once.
+    auto cellv = cell.notes().values();
+
+    for (auto const &pair_cell : set) {
+        // is this candidate pair cell good?
+        if (!NakedPairTechnique::test_naked_pair(cell, pair_cell, set)) continue;
+
+        // yes! but is it already recorded?
+        NakedPairFinding np({cell.coord(), pair_cell.coord()}, {cellv.at(0), cellv.at(1)});
+        bool already = false;
+        for (auto const &f : out) {
+            assert(dynamic_cast<const NakedPairFinding *>(f.get()));
+            if (static_cast<const NakedPairFinding *>(f.get())->same(np)) { already = true; break; }
+        }
+        if (already) continue;
+
+        // no! let's record it
+        if (sVerbose) { std::cout << "  [fNP] "; np.print(std::cout); std::cout << std::endl; }
+        out.push_back(std::make_shared<NakedPairFinding>(np));
+        return true;
+    }
+
+    return false;
 }
 
+// Apply one recorded pair to one `set`, eliminating its two values from the other
+// cells. Was Analyzer::act_on_naked_pair(entry, set); the board is now the passed
+// reference, and the pair's cells are addressed by coord (findings carry coords,
+// and Cell equality / set membership are coord-based anyway) rather than resolved
+// through the friends-only Board::at the member had via Analyzer's friendship.
 template<class Set>
-bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) const {
+bool act_on_naked_pair(Board &board, const NakedPairFinding &entry, const Set &set) {
+    bool did_act = false;
+
+    const Coord &c1 = entry.coords.first;
+    const Coord &c2 = entry.coords.second;
+
+    // this is not the set to act on unless it also contains the pair's second
+    // cell (was set.contains(cell2); contains compares by coord).
+    bool contains_c2 = false;
+    for (auto const &cell : set) if (cell.coord() == c2) { contains_c2 = true; break; }
+    if (!contains_c2) return did_act;
+
+    for (auto const &other_cell : set) {
+        if (other_cell.isValue()) continue;
+        if (other_cell.coord() == c1 || other_cell.coord() == c2) continue; // not looking at either of the cell pairs
+
+        if (other_cell.check(entry.values.first)) {
+            board.clear_note_at(other_cell.coord(), entry.values.first);
+            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.first << " [" << tag(set.kind()) << "]" << std::endl;
+            did_act = true;
+        }
+        if (other_cell.check(entry.values.second)) {
+            board.clear_note_at(other_cell.coord(), entry.values.second);
+            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.second << " [" << tag(set.kind()) << "]" << std::endl;
+            did_act = true;
+        }
+    }
+
+    return did_act;
+}
+} // namespace
+
+template<class Set>
+bool NakedPairTechnique::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) {
     // are these two different cells?
     if (c1 == c2) return false;
 
@@ -62,105 +151,54 @@ bool Analyzer::test_naked_pair(const Cell &c1, const Cell &c2, const Set &set) c
     return true;
 }
 
-template<class Set>
-bool Analyzer::find_naked_pair(const Cell &cell, const Set &set) {
-    // cell is fixed across the loop, so its candidate pair is too; enumerate once.
-    auto cellv = cell.notes().values();
-
-    for (auto const &pair_cell : set) {
-        // is this candidate pair cell good?
-        if (!test_naked_pair(cell, pair_cell, set)) continue;
-
-        // yes! but is it already recorded?
-        NakedPair np({cell.coord(), pair_cell.coord()}, {cellv.at(0), cellv.at(1)});
-        if (std::find(mNakedPairs.begin(), mNakedPairs.end(), np) != mNakedPairs.end()) continue;
-
-        // no! let's record it
-        mNakedPairs.push_back(np);
-        if (sVerbose) std::cout << "  [fNP] " << np << std::endl;
-        return true;
-    }
-
-    return false;
-}
-
-bool Analyzer::find_naked_pairs() {
-    // https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#subsets
-    // When n candidates are possible in a certain set of n cells all in the same block, row,
-    // or column, and no other candidates are possible in those cells, then those n candidates
-    // are not possible elsewhere in that same block, row, or column.
-    // Applied for n = 2
-    assert(mNakedPairs.empty());
+// https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#subsets
+// When n candidates are possible in a certain set of n cells all in the same block, row,
+// or column, and no other candidates are possible in those cells, then those n candidates
+// are not possible elsewhere in that same block, row, or column.
+// Applied for n = 2
+bool NakedPairTechnique::find(const Board &board, FindingList &out) const {
+    assert(out.empty());
     bool did_find = false;
 
-    for (auto const &cell: mBoard.cells()) {
+    for (auto const &cell: board.cells()) {
         // is this a note cell?
         if (!cell.isNote()) continue;
         // yes! but does it have only two notes?
         if (cell.notes().count() != 2) continue;
 
         // yes! let's see if we can find it a pair?
-        did_find |= find_naked_pair(cell, mBoard.row(cell));
-        did_find |= find_naked_pair(cell, mBoard.column(cell));
-        did_find |= find_naked_pair(cell, mBoard.nonet(cell));
+        did_find |= find_naked_pair(cell, board.row(cell), out);
+        did_find |= find_naked_pair(cell, board.column(cell), out);
+        did_find |= find_naked_pair(cell, board.nonet(cell), out);
     }
 
     return did_find;
 }
 
-template<class Set>
-bool Analyzer::act_on_naked_pair(const NakedPair &entry, Set &set) {
+bool NakedPairTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
+
     bool did_act = false;
+    for (auto const &f : mine) {
+        // Bucket invariant: see NakedSingleTechnique::apply for the rationale.
+        // The assert turns a wrong-bucket wiring bug into a caught error, not UB.
+        assert(dynamic_cast<const NakedPairFinding *>(f.get()));
+        auto const *np = static_cast<const NakedPairFinding *>(f.get());
 
-    auto const &cell1 = mBoard.at(entry.coords.first);
-    auto const &cell2 = mBoard.at(entry.coords.second);
-
-    if (!set.contains(cell2)) return did_act; // this is not the set to act on
-
-    for (auto &other_cell : set) {
-        if (other_cell.isValue()) continue;
-        if (other_cell == cell1 || other_cell == cell2) continue; // not looking at either of the cell pairs
-
-        if (other_cell.check(entry.values.first)) {
-            mBoard.clear_note_at(other_cell.coord(), entry.values.first);
-            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.first << " [" << tag(set.kind()) << "]" << std::endl;
-            did_act = true;
-        }
-        if (other_cell.check(entry.values.second)) {
-            mBoard.clear_note_at(other_cell.coord(), entry.values.second);
-            std::cout << "[NP] " << other_cell.coord() << " x" << entry.values.second << " [" << tag(set.kind()) << "]" << std::endl;
-            did_act = true;
-        }
+        // three units of the pair's first cell, addressed by coord
+        did_act |= act_on_naked_pair(board, *np, board.row(np->coords.first));
+        did_act |= act_on_naked_pair(board, *np, board.column(np->coords.first));
+        did_act |= act_on_naked_pair(board, *np, board.nonet(np->coords.first));
     }
-
-    return did_act;
-}
-
-bool Analyzer::act_on_naked_pair() {
-    bool did_act = false;
-
-    if (mNakedPairs.empty()) return did_act;
-
-    for (auto const &entry : mNakedPairs) {
-        auto const &cell1 = mBoard.at(entry.coords.first);
-
-        did_act |= act_on_naked_pair(entry, mBoard.row(cell1));
-        did_act |= act_on_naked_pair(entry, mBoard.column(cell1));
-        did_act |= act_on_naked_pair(entry, mBoard.nonet(cell1));
-    }
-    mNakedPairs.clear();
+    mine.clear();
 
     assert(did_act);
     return did_act;
 }
 
-// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp)
-// can link test_naked_pair<Row> directly. Its only in-TU caller is
-// find_naked_pair, which at -O3 g++ inlines, emitting no out-of-line copy of
-// the predicate; the external reference from the test TU then fails to link
-// (clang happens to keep a weak definition, so it only bit the gcc build).
-template bool Analyzer::test_naked_pair<Row>(const Cell &, const Cell &, const Row &) const;
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::NakedPair &np) {
-    return outs << "{" << np.coords.first << "," << np.coords.second << "}#{" << np.values.first << "," << np.values.second << "}";
-}
+// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp) can
+// link test_naked_pair<Row> directly. Its only in-TU caller is find_naked_pair,
+// which at -O3 g++ inlines, emitting no out-of-line copy of the predicate; the
+// external reference from the test TU then fails to link (clang happens to keep a
+// weak definition, so it only bit the gcc build). See docs/test-predicate-idiom.md.
+template bool NakedPairTechnique::test_naked_pair<Row>(const Cell &, const Cell &, const Row &);

--- a/analyzer-nakedpairs.h
+++ b/analyzer-nakedpairs.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+#include "cell.h"  // Cell, Value used in the test_naked_pair contract below
+
+// Naked pair: two note cells in the same unit (row, column, or nonet) sharing
+// the exact same bivalue candidate set; those two values can then be stripped
+// from every other cell of that unit.
+//
+// NP is the first *hooked* technique to port (issue #7): unlike Naked/Hidden
+// Singles, its validation predicate is exercised directly by the whitebox suite.
+// The concrete NakedPairFinding still lives file-local in the .cpp (the hook
+// tests the predicate, not the finding), but test_naked_pair is promoted here to
+// a tested public contract -- see below.
+class NakedPairTechnique : public Technique {
+public:
+    const char *name() const override { return "NP"; }
+    Tier        tier() const override { return Tier::Advanced; }
+    bool  brace_each() const override { return true; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+
+    // Tested contract, NOT a leaked private: is (c1, c2) a genuine, actionable
+    // naked pair within `set`? The old Analyzer::test_naked_pair was reached by a
+    // friend hook because techniques weren't standalone; now that NakedPairTechnique
+    // is standalone this is promoted to a public static so the whitebox suite judges
+    // crafted tuples directly, without friendship (issue #7's stated payoff).
+    // Templated on the unit type; an explicit Row instantiation in the .cpp forces
+    // an out-of-line symbol so the gcc -O3 cross-TU reference from the test links
+    // (see docs/test-predicate-idiom.md).
+    template<class Set>
+    static bool test_naked_pair(const Cell &c1, const Cell &c2, const Set &set);
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -34,6 +34,7 @@ const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
         std::vector<std::unique_ptr<Technique>> r;
         r.push_back(std::make_unique<NakedSingleTechnique>());
         r.push_back(std::make_unique<HiddenSingleTechnique>());
+        r.push_back(std::make_unique<NakedPairTechnique>());
         assert(r.size() <= std::size(kCascade));
         for (size_t i = 0; i < r.size(); ++i)
             assert(std::string_view(r[i]->name()) == kCascade[i]);
@@ -85,7 +86,6 @@ void Analyzer::analyze() {
     filter_notes();
 
     for (auto &b : mFindings) b.clear();
-    mNakedPairs.clear();
     mLockedCandidates.clear();
     mHiddenPairs.clear();
     mXWings.clear();
@@ -106,7 +106,6 @@ void Analyzer::analyze() {
     assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
-    if (!did_find) did_find = find_naked_pairs();
     if (!did_find) did_find = find_locked_candidates();
     if (!did_find) did_find = find_hidden_pairs();
     if (!did_find) did_find = find_xwings();
@@ -129,7 +128,6 @@ bool Analyzer::act(const bool singles_only) {
     }
 
     if (!singles_only) {
-        if (!did_act) did_act = act_on_naked_pair();
         if (!did_act) did_act = act_on_locked_candidate();
         if (!did_act) did_act = act_on_hidden_pair();
         if (!did_act) did_act = act_on_xwing();
@@ -188,7 +186,6 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }
-    print_section(outs, "NP", a.mNakedPairs,       true);  outs << std::endl;
     print_section(outs, "LC", a.mLockedCandidates, true);  outs << std::endl;
     print_section(outs, "HP", a.mHiddenPairs,      true);  outs << std::endl;
     print_section(outs, "XW", a.mXWings,           true);  outs << std::endl;

--- a/analyzer.h
+++ b/analyzer.h
@@ -18,7 +18,6 @@ public:
 
     Analyzer(Board &board, Analyzer const &other)
         : mFindings(other.mFindings)
-        , mNakedPairs(other.mNakedPairs)
         , mLockedCandidates(other.mLockedCandidates)
         , mHiddenPairs(other.mHiddenPairs)
         , mXWings(other.mXWings)
@@ -72,29 +71,6 @@ private:
     // -Wreorder; the rebinding-ctor regression test guards the one hand-written
     // mFindings(other.mFindings) copy.
     std::vector<FindingList> mFindings;
-
-private:
-    //** naked pairs
-    struct NakedPair {
-        std::pair<Coord, Coord> coords;
-        std::pair<Value, Value> values;
-
-        bool operator==(const NakedPair &other) const = default;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const NakedPair &);
-    std::vector<NakedPair> mNakedPairs;
-
-    // find
-    template<class Set>
-    bool test_naked_pair(const Cell &, const Cell &, const Set &) const;
-    template<class Set>
-    bool find_naked_pair(const Cell &, const Set &);
-    bool find_naked_pairs();
-
-    // act
-    template<class Set>
-    bool act_on_naked_pair(const NakedPair &, Set &);
-    bool act_on_naked_pair();
 
 private:
     //** locked candidates

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -77,8 +77,12 @@ materialized-object) and 3 inline (the 3 scan-fused). The codebase matches:
   is just validation of a given tuple, exactly like naked pair's would-act
   check), and it is extracted to a `test_hidden_pair` mirroring `test_naked_pair`
   (the old hand-rolled `condition_met` / `ppair_cell` single-pass bookkeeping is
-  gone). Like naked pair, the templated predicate is tested directly via a friend
-  hook plus an explicit `Row` instantiation (see "A note on templates" below).
+  gone). It is still private to `Analyzer` (not yet ported behind the registry),
+  so its templated predicate is tested directly via a friend hook plus an
+  explicit `Row` instantiation. Naked pair used that same friend-hook route until
+  it ported (issue #7); porting let it promote the predicate to a public `static`
+  member and drop the hook, so hidden pair is now the remaining friend-hook
+  worked example (see "A note on templates" below).
 
 - **X-Wing correctly has no `test_`.** It is scan-fused; PR #24 removed the dead
   predicate and kept `find_xwing` inline, tested through `find_` like its fish
@@ -102,18 +106,33 @@ PR #27 for `test_naked_pair`:
   linux-gcc. (PR #24 hit the same link failure from the other direction and shed
   it by deleting a dead predicate.)
 
-- **The fix, when you want direct per-branch tests.** Add a friend hook in
-  `AnalyzerTest` that instantiates the predicate on a concrete unit (e.g.
-  `test_naked_pair_row` calls `a.test_naked_pair(c1, c2, a.mBoard.row(c1))`), and
-  add an explicit instantiation next to the definition:
-  `template bool Analyzer::test_naked_pair<Row>(const Cell &, const Cell &, const Row &) const;`.
-  The explicit instantiation forces a standalone symbol regardless of inlining.
+- **The fix, when you want direct per-branch tests.** Whatever route the test
+  uses to reach the predicate, add an explicit instantiation next to the
+  definition so a standalone symbol is emitted regardless of inlining — this is
+  the part that fixes the gcc-only link failure, and it is needed either way. How
+  the test *names* the predicate depends on whether the technique has ported
+  behind the registry:
+  - **Still private to `Analyzer` (not yet ported):** add a friend hook in
+    `AnalyzerTest` that instantiates the predicate on a concrete unit (e.g.
+    `test_hidden_pair_row` calls `a.test_hidden_pair(c1, c2, v1, v2, a.mBoard.row(c1))`),
+    with `template bool Analyzer::test_hidden_pair<Row>(...) const;` beside the
+    definition.
+  - **Ported behind the registry (standalone `Technique`):** the predicate has no
+    `Analyzer` to be private to, so promote it to a public `static` member of the
+    technique — a documented tested contract — and have the test call it directly,
+    no friendship required. Naked pair took this route (issue #7): the test calls
+    `NakedPairTechnique::test_naked_pair<Row>(...)` and the friend hook is deleted.
+    Because the member is `static` there is no trailing `const`, and the explicit
+    instantiation is likewise unqualified by `Analyzer`:
+    `template bool NakedPairTechnique::test_naked_pair<Row>(const Cell &, const Cell &, const Row &);`.
   Confirm on CI, not locally: the Apple-clang `g++` shim cannot reproduce the
   gcc-only link failure.
 
 - **The decision.** When extracting a templated predicate, choose up front: test
-  it through `find_` (cheap, coarser, no link tax), or pay the friend-hook +
-  explicit-instantiation tax for direct per-branch predicate tests.
-  `test_naked_pair` and `test_hidden_pair` (in `tests/unit/test_analyzer.cpp`,
-  `analyzer-nakedpairs.cpp`, and `analyzer-hiddenpairs.cpp`) both took the second
-  route and are the worked examples to copy.
+  it through `find_` (cheap, coarser, no link tax), or pay the
+  explicit-instantiation tax (plus a friend hook, if the technique is still
+  private to `Analyzer`) for direct per-branch predicate tests. Both worked
+  examples, driven from `tests/unit/test_analyzer.cpp`, took the second route:
+  `test_hidden_pair` (`analyzer-hiddenpairs.cpp`) is the friend-hook variant, and
+  `test_naked_pair` (`analyzer-nakedpairs.h` / `analyzer-nakedpairs.cpp`) is the
+  promoted public-static-member variant.

--- a/techniques.h
+++ b/techniques.h
@@ -8,3 +8,4 @@
 
 #include "analyzer-nakedsingles.h"
 #include "analyzer-hiddensingles.h"
+#include "analyzer-nakedpairs.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -17,6 +17,7 @@
 
 #include "board.h"
 #include "analyzer.h"
+#include "analyzer-nakedpairs.h"
 #include "cell.h"
 #include "coord.h"
 
@@ -106,12 +107,9 @@ struct AnalyzerTest {
     static Value  xwing_value(const Analyzer &a)                         { return a.mXWings.at(0).value; }
 
     // --- naked pair ---
-    // test_naked_pair is given-tuple shaped: find_ enumerates cell pairs and the
-    // predicate judges each. Drive it directly on a crafted unit. It is a
-    // template on the set type; instantiate it on the cells' shared Row.
-    static bool test_naked_pair_row(const Analyzer &a, const Cell &c1, const Cell &c2) {
-        return a.test_naked_pair(c1, c2, a.mBoard.row(c1));
-    }
+    // No hook: NP is ported to a standalone NakedPairTechnique (issue #7), whose
+    // test_naked_pair is a promoted public static -- the whitebox case calls it
+    // directly, without friendship. (HP below still needs a hook until it ports.)
 
     // --- hidden pair ---
     // test_hidden_pair is given-tuple shaped too (identity is (c1,c2,v1,v2)):
@@ -436,13 +434,14 @@ void test_naked_pair_accept_and_reject() {
     set_candidates(board, 0, 0, {3, 5});   // the pair...
     set_candidates(board, 0, 1, {3, 5});   // ...its twin in the same row
     set_candidates(board, 0, 2, {3, 6});   // shares only one value -- not a pair
-    Analyzer analyzer(board);
 
-    check(AnalyzerTest::test_naked_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1)),
+    // The predicate is a promoted public static (no friend hook): call it directly,
+    // instantiated on the cells' shared Row.
+    check(NakedPairTechnique::test_naked_pair(cell_at(board, 0, 0), cell_at(board, 0, 1), board.row(cell_at(board, 0, 0))),
           "accepted: two cells holding the same candidate pair {3,5}");
     // Reject short-circuits on the set compare, before would_act: a pure
     // pair-match check, immune to changes in actionability logic.
-    check(!AnalyzerTest::test_naked_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 2)),
+    check(!NakedPairTechnique::test_naked_pair(cell_at(board, 0, 0), cell_at(board, 0, 2), board.row(cell_at(board, 0, 0))),
           "rejected: candidate sets {3,5} and {3,6} differ");
 
     // --- actionability gate (would_act) ---
@@ -454,9 +453,8 @@ void test_naked_pair_accept_and_reject() {
     set_candidates(inert, 0, 1, {7, 8});
     confine_value(inert, kSeven, { {0, 0}, {0, 1} });
     confine_value(inert, kEight, { {0, 0}, {0, 1} });
-    Analyzer inert_analyzer(inert);
 
-    check(!AnalyzerTest::test_naked_pair_row(inert_analyzer, cell_at(inert, 0, 0), cell_at(inert, 0, 1)),
+    check(!NakedPairTechnique::test_naked_pair(cell_at(inert, 0, 0), cell_at(inert, 0, 1), inert.row(cell_at(inert, 0, 0))),
           "rejected: a real pair with nothing to act on (would_act gate)");
 }
 
@@ -752,8 +750,8 @@ void test_rebinding_ctor_carries_findings() {
 
     Analyzer a(board);
     a.analyze();
-    check(AnalyzerTest::findings_bucket_count(a) == 2, "two registry buckets (NS, HS)");
-    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS short-circuited)");
+    check(AnalyzerTest::findings_bucket_count(a) == 3, "three registry buckets (NS, HS, NP)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP short-circuited)");
 
     // Copy the candidate grid and rebind onto it -- this is the ONLY operation
     // under test. b.analyze() is deliberately never called.


### PR DESCRIPTION
Third technique in the issue-#7 registry series (after NS #37 and HS #39): move Naked Pairs out of the `Analyzer` god-class into a standalone `NakedPairTechnique`, third in cascade order.

## What changed
- **`analyzer-nakedpairs.h`** (new): `NakedPairTechnique` (tier `Advanced`, `brace_each() == true`), plus `test_naked_pair` promoted to a public `static` template member.
- **`analyzer-nakedpairs.cpp`** (rewritten): file-local `NakedPairFinding`, the `would_act`/find/act helpers, `find`/`apply`/`test_naked_pair`, and the explicit `Row` instantiation.
- **`analyzer.h` / `analyzer.cpp`**: NP block + rebinding-ctor initializer deleted; NP registered after HS; removed from the `clear`/`find`/`act`/`operator<<` hand-written sites.
- **`techniques.h`**: include added. **`tests/unit/test_analyzer.cpp`**: friend hook deleted, predicate called directly, registry bucket count `2 → 3`.
- **`docs/test-predicate-idiom.md`**: records the seam route rule (still-private → friend hook; ported → promoted public static).

## Seam precedent (first hooked technique)
NP is the first *hooked* technique to port. Now that the technique is standalone, `test_naked_pair` moves from an `Analyzer` private reached via an `AnalyzerTest` friend hook to a public static member (a documented tested contract) the whitebox test calls directly — the payoff issue #7 predicted. The concrete `NakedPairFinding` stays file-local (the hook tests the predicate, not the finding). This sets the route for the remaining pattern-B technique, HP.

`apply()` addresses the pair's cells by coord instead of resolving coord→`Cell` through the friends-only `Board::at`, so **Board is untouched**.

## Verification
- `make unit` all pass; `make test` **80/0**.
- **Byte-identical**: full `v`+solve REPL transcripts diffed against the pre-port binary (built from the parent commit in a worktree) across **six NP-exercising boards** — zero diff.
- Clean `-Wall -Werror` build; no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)