### PR TITLE
Technique registry: port Locked Candidates (#7)

### DIFF
--- a/analyzer-lockedcandidates.cpp
+++ b/analyzer-lockedcandidates.cpp
@@ -1,26 +1,63 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-lockedcandidates.h"
 #include "board.h"
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
 
 #include <algorithm>
+#include <cassert>
+#include <memory>
+#include <utility>
+#include <vector>
 
-bool Analyzer::LockedCandidates::operator==(const LockedCandidates &other) const {
-    if (unit != other.unit) return false;
-    if (value != other.value) return false;
-    if (coords.size() != other.coords.size()) return false;
-    for (const Coord &c : coords) {
-        if (std::find(other.coords.begin(), other.coords.end(), c) == other.coords.end()) {
-            return false;
-        }
+namespace {
+// File-local: LC has no whitebox hooks, so nothing outside this TU needs to name
+// or downcast the finding. print() emits the same bytes the old free
+// operator<<(ostream, Analyzer::LockedCandidates) did: "{c1,c2,...}#value[^unit]".
+struct LockedCandidatesFinding : Finding {
+    std::vector<Coord> coords;
+    Value value;
+    Unit  unit;
+    LockedCandidatesFinding(std::vector<Coord> c, Value v, Unit u)
+        : coords(std::move(c)), value(v), unit(u) { }
+
+    // Order-independent equality on the coord set, matching the old
+    // Analyzer::LockedCandidates::operator==: the two find forms enumerate the
+    // same locked group from different starting cells, so the coord vectors can
+    // differ in order while denoting the same finding.
+    bool same(const LockedCandidatesFinding &o) const {
+        if (unit != o.unit) return false;
+        if (value != o.value) return false;
+        if (coords.size() != o.coords.size()) return false;
+        for (const Coord &c : coords)
+            if (std::find(o.coords.begin(), o.coords.end(), c) == o.coords.end()) return false;
+        return true;
     }
-    return true;
-}
 
+    void print(std::ostream &o) const override {
+        o << "{";
+        bool is_first = true;
+        for (auto const &coord : coords) {
+            if (!is_first) { o << ","; }
+            is_first = false;
+            o << coord;
+        }
+        o << "}#" << value << "[^" << tag(unit) << "]";
+    }
+};
+
+// Find a locked candidate for (cell, value): all candidate cells for `value` in
+// set_to_consider must also lie in set_to_ignore, and acting must actually
+// eliminate something from the rest of set_to_ignore. Was
+// Analyzer::find_locked_candidate; the member vector dedup is now a scan of
+// `out` (this technique's own bucket, so every entry downcasts to
+// LockedCandidatesFinding).
 template<class Set1, class Set2>
-bool Analyzer::find_locked_candidate(const Cell &cell, const Value &value, Set1 &set_to_consider, Set2 &set_to_ignore) {
+bool find_locked_candidate(const Cell &cell, const Value &value,
+                           const Set1 &set_to_consider, const Set2 &set_to_ignore, FindingList &out) {
     bool did_find = false;
 
     std::vector<Coord> lc_coords;
@@ -70,55 +107,30 @@ bool Analyzer::find_locked_candidate(const Cell &cell, const Value &value, Set1 
 
     if (would_act) {
         // but is this entry already recorded?
-        LockedCandidates lc(lc_coords, value, set_to_ignore.kind());
-        if (std::find(mLockedCandidates.begin(), mLockedCandidates.end(), lc) != mLockedCandidates.end()) return did_find;
+        LockedCandidatesFinding lc(lc_coords, value, set_to_ignore.kind());
+        for (auto const &f : out) {
+            assert(dynamic_cast<const LockedCandidatesFinding *>(f.get()));
+            if (static_cast<const LockedCandidatesFinding *>(f.get())->same(lc)) return did_find;
+        }
 
         // no! let's record it
-        mLockedCandidates.push_back(lc);
-        if (sVerbose) std::cout << "  [fLC] " << lc << std::endl;
+        if (sVerbose) { std::cout << "  [fLC] "; lc.print(std::cout); std::cout << std::endl; }
+        out.push_back(std::make_shared<LockedCandidatesFinding>(std::move(lc)));
         did_find = true;
     }
 
     return did_find;
 }
 
-bool Analyzer::find_locked_candidates() {
-    // https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#blocks
-    // Form 1:
-    // When a candidate is possible in a certain nonet and row/column, and it is not possible anywhere else in the same row/column,
-    // then it is also not possible anywhere else in the same nonet
-    // Form 2:
-    // When a candidate is possible in a certain nonet and row/column, and it is not possible anywhere else in the same nonet,
-    // then it is also not possible anywhere else in the same row/column
-    assert(mLockedCandidates.empty());
-    bool did_find = false;
-
-    for (auto const &cell: mBoard.cells()) {
-        // is this a note cell?
-        if (!cell.isNote()) continue;
-
-
-        // yes! then for each candidate value in this note cell
-        for (auto const &value : cell.notes().values()) {
-
-            // form 1
-            did_find |= find_locked_candidate(cell, value, mBoard.row(cell), mBoard.nonet(cell));
-            did_find |= find_locked_candidate(cell, value, mBoard.column(cell), mBoard.nonet(cell));
-
-            // form 2
-            did_find |= find_locked_candidate(cell, value, mBoard.nonet(cell), mBoard.row(cell));
-            did_find |= find_locked_candidate(cell, value, mBoard.nonet(cell), mBoard.column(cell));
-        }
-    }
-
-    return did_find;
-}
-
+// Apply one recorded finding to one `set`, eliminating its value from every
+// cell of the set that is not itself a locked candidate. Was
+// Analyzer::act_on_locked_candidate(entry, set); the board is now the passed
+// reference (the member reached it through Analyzer's mBoard).
 template<class Set>
-bool Analyzer::act_on_locked_candidate(const LockedCandidates &entry, Set &set) {
+bool act_on_locked_candidate(Board &board, const LockedCandidatesFinding &entry, const Set &set) {
     bool did_act = false;
 
-    for (auto &other_cell : set) {
+    for (auto const &other_cell : set) {
         // is this a note cell?
         if (!other_cell.isNote()) continue;
 
@@ -131,45 +143,69 @@ bool Analyzer::act_on_locked_candidate(const LockedCandidates &entry, Set &set) 
 
         // yes! we'll act
         std::cout << "[LC] " << other_cell.coord() << " x" << entry.value << " [" << tag(entry.unit) << "]" << std::endl;
-        mBoard.clear_note_at(other_cell.coord(), entry.value);
+        board.clear_note_at(other_cell.coord(), entry.value);
         did_act = true;
     }
 
     return did_act;
 }
+} // namespace
 
-bool Analyzer::act_on_locked_candidate() {
+// https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#blocks
+// Form 1:
+// When a candidate is possible in a certain nonet and row/column, and it is not possible anywhere else in the same row/column,
+// then it is also not possible anywhere else in the same nonet
+// Form 2:
+// When a candidate is possible in a certain nonet and row/column, and it is not possible anywhere else in the same nonet,
+// then it is also not possible anywhere else in the same row/column
+bool LockedCandidatesTechnique::find(const Board &board, FindingList &out) const {
+    assert(out.empty());
+    bool did_find = false;
+
+    for (auto const &cell: board.cells()) {
+        // is this a note cell?
+        if (!cell.isNote()) continue;
+
+        // yes! then for each candidate value in this note cell
+        for (auto const &value : cell.notes().values()) {
+
+            // form 1
+            did_find |= find_locked_candidate(cell, value, board.row(cell), board.nonet(cell), out);
+            did_find |= find_locked_candidate(cell, value, board.column(cell), board.nonet(cell), out);
+
+            // form 2
+            did_find |= find_locked_candidate(cell, value, board.nonet(cell), board.row(cell), out);
+            did_find |= find_locked_candidate(cell, value, board.nonet(cell), board.column(cell), out);
+        }
+    }
+
+    return did_find;
+}
+
+bool LockedCandidatesTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
+
     bool did_act = false;
+    for (auto const &f : mine) {
+        // Bucket invariant: see NakedSingleTechnique::apply for the rationale.
+        // The assert turns a wrong-bucket wiring bug into a caught error, not UB.
+        assert(dynamic_cast<const LockedCandidatesFinding *>(f.get()));
+        auto const *lc = static_cast<const LockedCandidatesFinding *>(f.get());
 
-    if (mLockedCandidates.empty()) return did_act;
-
-    for (auto const &entry : mLockedCandidates) {
-        switch (entry.unit) {
+        switch (lc->unit) {
         case Unit::Row:
-            did_act |= act_on_locked_candidate(entry, mBoard.row(entry.coords.at(0)));
+            did_act |= act_on_locked_candidate(board, *lc, board.row(lc->coords.at(0)));
             break;
         case Unit::Column:
-            did_act |= act_on_locked_candidate(entry, mBoard.column(entry.coords.at(0)));
+            did_act |= act_on_locked_candidate(board, *lc, board.column(lc->coords.at(0)));
             break;
         case Unit::Nonet:
-            did_act |= act_on_locked_candidate(entry, mBoard.nonet(entry.coords.at(0)));
+            did_act |= act_on_locked_candidate(board, *lc, board.nonet(lc->coords.at(0)));
             break;
         }
     }
-    mLockedCandidates.clear();
+    mine.clear();
 
     assert(did_act);
     return did_act;
-}
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::LockedCandidates &lc) {
-    outs << "{";
-    bool is_first = true;
-    for (auto const &coord : lc.coords) {
-        if (!is_first) { outs << ","; }
-        is_first = false;
-        outs << coord;
-    }
-    outs << "}#" << lc.value << "[^" << tag(lc.unit) << "]";
-    return outs;
 }

--- a/analyzer-lockedcandidates.h
+++ b/analyzer-lockedcandidates.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+
+// Locked candidates: a value whose candidate cells in one unit (row, column, or
+// nonet) all fall inside a second, overlapping unit. The value is then locked to
+// that overlap and can be eliminated from the rest of the second unit.
+// https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#blocks
+//
+// Like Naked/Hidden Singles, LC has no whitebox hooks, so the concrete
+// LockedCandidatesFinding lives file-local in the .cpp; only the technique class
+// needs to be nameable here (registry() constructs it directly).
+class LockedCandidatesTechnique : public Technique {
+public:
+    const char *name() const override { return "LC"; }
+    Tier        tier() const override { return Tier::Advanced; }
+    bool  brace_each() const override { return true; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -35,6 +35,7 @@ const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
         r.push_back(std::make_unique<NakedSingleTechnique>());
         r.push_back(std::make_unique<HiddenSingleTechnique>());
         r.push_back(std::make_unique<NakedPairTechnique>());
+        r.push_back(std::make_unique<LockedCandidatesTechnique>());
         assert(r.size() <= std::size(kCascade));
         for (size_t i = 0; i < r.size(); ++i)
             assert(std::string_view(r[i]->name()) == kCascade[i]);
@@ -86,7 +87,6 @@ void Analyzer::analyze() {
     filter_notes();
 
     for (auto &b : mFindings) b.clear();
-    mLockedCandidates.clear();
     mHiddenPairs.clear();
     mXWings.clear();
     mSwordfish.clear();
@@ -106,7 +106,6 @@ void Analyzer::analyze() {
     assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
-    if (!did_find) did_find = find_locked_candidates();
     if (!did_find) did_find = find_hidden_pairs();
     if (!did_find) did_find = find_xwings();
     if (!did_find) did_find = find_color_chains();
@@ -128,7 +127,6 @@ bool Analyzer::act(const bool singles_only) {
     }
 
     if (!singles_only) {
-        if (!did_act) did_act = act_on_locked_candidate();
         if (!did_act) did_act = act_on_hidden_pair();
         if (!did_act) did_act = act_on_xwing();
         if (!did_act) did_act = act_on_color_chain();
@@ -186,7 +184,6 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }
-    print_section(outs, "LC", a.mLockedCandidates, true);  outs << std::endl;
     print_section(outs, "HP", a.mHiddenPairs,      true);  outs << std::endl;
     print_section(outs, "XW", a.mXWings,           true);  outs << std::endl;
     print_section(outs, "SC", a.mColorChains,      true);  outs << std::endl; // a.k.a. single's chains

--- a/analyzer.h
+++ b/analyzer.h
@@ -18,7 +18,6 @@ public:
 
     Analyzer(Board &board, Analyzer const &other)
         : mFindings(other.mFindings)
-        , mLockedCandidates(other.mLockedCandidates)
         , mHiddenPairs(other.mHiddenPairs)
         , mXWings(other.mXWings)
         , mSwordfish(other.mSwordfish)
@@ -71,28 +70,6 @@ private:
     // -Wreorder; the rebinding-ctor regression test guards the one hand-written
     // mFindings(other.mFindings) copy.
     std::vector<FindingList> mFindings;
-
-private:
-    //** locked candidates
-    struct LockedCandidates {
-        std::vector<Coord> coords;
-        Value value;
-        Unit unit;
-
-        bool operator==(const LockedCandidates &other) const;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const LockedCandidates &);
-    std::vector<LockedCandidates> mLockedCandidates;
-
-    // find
-    template<class Set1, class Set2>
-    bool find_locked_candidate(const Cell &, const Value &, Set1 &set_to_consider, Set2 &set_to_ignore);
-    bool find_locked_candidates();
-
-    // act
-    template<class Set>
-    bool act_on_locked_candidate(const LockedCandidates &, Set &);
-    bool act_on_locked_candidate();
 
 private:
     //** hidden pairs

--- a/techniques.h
+++ b/techniques.h
@@ -9,3 +9,4 @@
 #include "analyzer-nakedsingles.h"
 #include "analyzer-hiddensingles.h"
 #include "analyzer-nakedpairs.h"
+#include "analyzer-lockedcandidates.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -750,8 +750,8 @@ void test_rebinding_ctor_carries_findings() {
 
     Analyzer a(board);
     a.analyze();
-    check(AnalyzerTest::findings_bucket_count(a) == 3, "three registry buckets (NS, HS, NP)");
-    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP short-circuited)");
+    check(AnalyzerTest::findings_bucket_count(a) == 4, "four registry buckets (NS, HS, NP, LC)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC short-circuited)");
 
     // Copy the candidate grid and rebind onto it -- this is the ONLY operation
     // under test. b.analyze() is deliberately never called.


### PR DESCRIPTION
Fourth technique port in the issue #7 series: moves **Locked Candidates** out of the `Analyzer` god-class into a standalone `LockedCandidatesTechnique` in the ordered registry, after NS, HS, NP.

## What changed
- **New** `analyzer-lockedcandidates.h` — the technique class (`"LC"`, `Tier::Advanced`, `brace_each() == true`).
- **Rewrote** `analyzer-lockedcandidates.cpp`:
  - File-local `LockedCandidatesFinding : Finding` (LC is non-hooked, like NS/HS). `print()` reproduces the old free `operator<<` byte-for-byte: `{c1,c2,...}#value[^unit]`.
  - The old `LockedCandidates::operator==` (order-independent coord-set equality) becomes `same()` and dedups against the technique's own bucket.
  - `find`/`apply` use the public `row/column/nonet` accessors and address cells by coord — no Board friendship needed.
- **Removed** from `analyzer.h`/`analyzer.cpp`: the `LockedCandidates` struct, `mLockedCandidates` member + rebinding-ctor initializer, the find/act declarations, and the four hand-written suffix sites (clear / analyze / act / `operator<<`). Added one registry line + one `techniques.h` include.
- **Test**: rebinding-ctor whitebox bucket count 3 → 4 (NS, HS, NP, LC).

The registry is now the `NS, HS, NP, LC` prefix of the canonical cascade; the `kCascade` guard's runtime assert confirms order at construction.

## Verification
- Build clean (`-Wall -Werror`, -O3).
- **Byte-identical** full-solve REPL transcripts across six fixtures (P_easy, P_med, P_clm, P_adv, P_hard, P_sf) — no behavior change.
- `make test`: 80/0. `make unit`: all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)