### PR TITLE
Technique registry: port Hidden Pairs (#7)

### DIFF
--- a/analyzer-hiddenpairs.cpp
+++ b/analyzer-hiddenpairs.cpp
@@ -27,16 +27,6 @@ struct HiddenPairFinding : Finding {
     }
 };
 
-// Resolve a coord to its cell without Board::at (friends-only, dropped when the
-// technique left Analyzer -- see the roadmap note). The cell's own row is the
-// cheapest public unit that contains it; scan it for the matching coord.
-const Cell &cell_at(const Board &board, const Coord &coord) {
-    for (auto const &cell : board.row(coord))
-        if (cell.coord() == coord) return cell;
-    assert(false);  // a coord always lies in its own row
-    return board.cells().front();
-}
-
 // Find a hidden pair for (cell, v1, v2) within `set`, if any, appending it to
 // `out`. Was Analyzer::find_hidden_pair; the member vector dedup is now a scan of
 // `out` (this technique's own bucket, so every entry downcasts to HiddenPairFinding).
@@ -64,21 +54,24 @@ bool find_hidden_pair(const Cell &cell, const Value &v1, const Value &v2, const 
     return false;
 }
 
-// Strip every candidate other than the hidden pair's two values from `cell`. Was
-// Analyzer::act_on_hidden_pair(cell, entry); the board is now the passed reference
-// (the member reached it through Analyzer's mBoard).
-bool act_on_hidden_pair(Board &board, const Cell &cell, const HiddenPairFinding &entry) {
+// Strip every candidate other than the hidden pair's two values from the cell at
+// `coord`. Was Analyzer::act_on_hidden_pair(cell, entry); coord-native like Naked
+// Pairs (no coord->Cell resolution). clear_note_at is a no-op returning false for
+// an absent note (board.cpp), so enumerating value_range() and acting on its
+// return strips exactly the candidates the old cell.notes().values() loop did, in
+// the same ascending order (values() is value_range() filtered) -- byte-identical.
+bool act_on_hidden_pair(Board &board, const Coord &coord, const HiddenPairFinding &entry) {
     bool did_act = false;
 
     auto const &v1 = entry.values.first;
     auto const &v2 = entry.values.second;
 
-    for (auto const &value : cell.notes().values()) {
+    for (Value value : value_range()) {
         if (value == v1) continue;
         if (value == v2) continue;
 
-        board.clear_note_at(cell.coord(), value);
-        std::cout << "[HP] " << cell.coord() << " x" << value << " "; entry.print(std::cout); std::cout << std::endl;
+        if (!board.clear_note_at(coord, value)) continue;  // absent note -> no-op
+        std::cout << "[HP] " << coord << " x" << value << " "; entry.print(std::cout); std::cout << std::endl;
         did_act = true;
     }
 
@@ -174,8 +167,8 @@ bool HiddenPairTechnique::apply(Board &board, FindingList &mine) const {
         auto const *hp = static_cast<const HiddenPairFinding *>(f.get());
 
         // the pair's two cells, addressed by coord (findings carry coords)
-        did_act |= act_on_hidden_pair(board, cell_at(board, hp->coords.first), *hp);
-        did_act |= act_on_hidden_pair(board, cell_at(board, hp->coords.second), *hp);
+        did_act |= act_on_hidden_pair(board, hp->coords.first, *hp);
+        did_act |= act_on_hidden_pair(board, hp->coords.second, *hp);
     }
     mine.clear();
 

--- a/analyzer-hiddenpairs.cpp
+++ b/analyzer-hiddenpairs.cpp
@@ -1,21 +1,100 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-hiddenpairs.h"
 #include "board.h"
+#include "row.h"  // Row: the explicit test_hidden_pair instantiation at file end
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
 
-#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <utility>
+
+namespace {
+// File-local: HP's whitebox hook tests the predicate, not the finding, so nothing
+// outside this TU needs to name or downcast HiddenPairFinding. print() emits the
+// same bytes the old free operator<<(ostream, Analyzer::HiddenPair) did:
+// "{coord1,coord2}#{value1,value2}".
+struct HiddenPairFinding : Finding {
+    std::pair<Coord, Coord> coords;
+    std::pair<Value, Value> values;
+    HiddenPairFinding(std::pair<Coord, Coord> c, std::pair<Value, Value> v) : coords(c), values(v) { }
+    bool same(const HiddenPairFinding &o) const { return coords == o.coords && values == o.values; }
+    void print(std::ostream &o) const override {
+        o << "{" << coords.first << "," << coords.second << "}#{" << values.first << "," << values.second << "}";
+    }
+};
+
+// Resolve a coord to its cell without Board::at (friends-only, dropped when the
+// technique left Analyzer -- see the roadmap note). The cell's own row is the
+// cheapest public unit that contains it; scan it for the matching coord.
+const Cell &cell_at(const Board &board, const Coord &coord) {
+    for (auto const &cell : board.row(coord))
+        if (cell.coord() == coord) return cell;
+    assert(false);  // a coord always lies in its own row
+    return board.cells().front();
+}
+
+// Find a hidden pair for (cell, v1, v2) within `set`, if any, appending it to
+// `out`. Was Analyzer::find_hidden_pair; the member vector dedup is now a scan of
+// `out` (this technique's own bucket, so every entry downcasts to HiddenPairFinding).
+template<class Set>
+bool find_hidden_pair(const Cell &cell, const Value &v1, const Value &v2, const Set &set, FindingList &out) {
+    for (auto const &other_cell : set) {
+        // is this candidate hidden pair good?
+        if (!HiddenPairTechnique::test_hidden_pair(cell, other_cell, v1, v2, set)) continue;
+
+        // yes! but is it already recorded?
+        HiddenPairFinding hp({cell.coord(), other_cell.coord()}, {v1, v2});
+        bool already = false;
+        for (auto const &f : out) {
+            assert(dynamic_cast<const HiddenPairFinding *>(f.get()));
+            if (static_cast<const HiddenPairFinding *>(f.get())->same(hp)) { already = true; break; }
+        }
+        if (already) continue;
+
+        // no! let's record it
+        if (sVerbose) { std::cout << "  [fHP] "; hp.print(std::cout); std::cout << std::endl; }
+        out.push_back(std::make_shared<HiddenPairFinding>(hp));
+        return true;
+    }
+
+    return false;
+}
+
+// Strip every candidate other than the hidden pair's two values from `cell`. Was
+// Analyzer::act_on_hidden_pair(cell, entry); the board is now the passed reference
+// (the member reached it through Analyzer's mBoard).
+bool act_on_hidden_pair(Board &board, const Cell &cell, const HiddenPairFinding &entry) {
+    bool did_act = false;
+
+    auto const &v1 = entry.values.first;
+    auto const &v2 = entry.values.second;
+
+    for (auto const &value : cell.notes().values()) {
+        if (value == v1) continue;
+        if (value == v2) continue;
+
+        board.clear_note_at(cell.coord(), value);
+        std::cout << "[HP] " << cell.coord() << " x" << value << " "; entry.print(std::cout); std::cout << std::endl;
+        did_act = true;
+    }
+
+    return did_act;
+}
+} // namespace
 
 template<class Set>
-bool Analyzer::test_hidden_pair(const Cell &c1, const Cell &c2,
-                                const Value &v1, const Value &v2, const Set &set) const {
+bool HiddenPairTechnique::test_hidden_pair(const Cell &c1, const Cell &c2,
+                                           const Value &v1, const Value &v2, const Set &set) {
     // are these two different cells, carrying two different values?
     if (c1 == c2) return false;
     if (v1 == v2) return false;
 
-    // yes! but is v2 strictly "after" v1? (find_ enumerates v1<v2; the friend
-    // hook can pass them either way, so the predicate guards the precondition
+    // yes! but is v2 strictly "after" v1? (find_ enumerates v1<v2; a direct test
+    // caller can pass them either way, so the predicate guards the precondition
     // itself. The v1==v2 case above is the other half of that guard.)
     if (v2 < v1) return false;
 
@@ -51,35 +130,16 @@ bool Analyzer::test_hidden_pair(const Cell &c1, const Cell &c2,
     return true;
 }
 
-template<class Set>
-bool Analyzer::find_hidden_pair(const Cell &cell, const Value &v1, const Value &v2, const Set &set) {
-    for (auto const &other_cell : set) {
-        // is this candidate hidden pair good?
-        if (!test_hidden_pair(cell, other_cell, v1, v2, set)) continue;
-
-        // yes! but is it already recorded?
-        HiddenPair hp({cell.coord(), other_cell.coord()}, {v1, v2});
-        if (std::find(mHiddenPairs.begin(), mHiddenPairs.end(), hp) != mHiddenPairs.end()) continue;
-
-        // no! let's record it
-        mHiddenPairs.push_back(hp);
-        if (sVerbose) std::cout << "  [fHP] " << hp << std::endl;
-        return true;
-    }
-
-    return false;
-}
-
-bool Analyzer::find_hidden_pairs() {
-    // https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#subsets
-    // When n candidates are possible in a certain set of n cells all in the same block, row, or column,
-    // and those n candidates are not possible elsewhere in that same block, row, or column, then no other
-    // candidates are possible in those cells.
-    // Applied for n = 2
-    assert(mHiddenPairs.empty());
+// https://www.stolaf.edu/people/hansonr/sudoku/explain.htm#subsets
+// When n candidates are possible in a certain set of n cells all in the same block, row, or column,
+// and those n candidates are not possible elsewhere in that same block, row, or column, then no other
+// candidates are possible in those cells.
+// Applied for n = 2
+bool HiddenPairTechnique::find(const Board &board, FindingList &out) const {
+    assert(out.empty());
     bool did_find = false;
 
-    for (auto const &cell: mBoard.cells()) {
+    for (auto const &cell: board.cells()) {
         // is this a note cell?
         if (!cell.isNote()) continue;
 
@@ -93,9 +153,9 @@ bool Analyzer::find_hidden_pairs() {
                 assert(*pv2 != *pv1);
 
                 // let's see if we can find a hidden pair in the three cell sets
-                did_find |= find_hidden_pair(cell, *pv1, *pv2, mBoard.row(cell));
-                did_find |= find_hidden_pair(cell, *pv1, *pv2, mBoard.column(cell));
-                did_find |= find_hidden_pair(cell, *pv1, *pv2, mBoard.nonet(cell));
+                did_find |= find_hidden_pair(cell, *pv1, *pv2, board.row(cell), out);
+                did_find |= find_hidden_pair(cell, *pv1, *pv2, board.column(cell), out);
+                did_find |= find_hidden_pair(cell, *pv1, *pv2, board.nonet(cell), out);
             }
         }
     }
@@ -103,49 +163,29 @@ bool Analyzer::find_hidden_pairs() {
     return did_find;
 }
 
-bool Analyzer::act_on_hidden_pair(Cell &cell, const HiddenPair &entry) {
+bool HiddenPairTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
+
     bool did_act = false;
+    for (auto const &f : mine) {
+        // Bucket invariant: see NakedSingleTechnique::apply for the rationale.
+        // The assert turns a wrong-bucket wiring bug into a caught error, not UB.
+        assert(dynamic_cast<const HiddenPairFinding *>(f.get()));
+        auto const *hp = static_cast<const HiddenPairFinding *>(f.get());
 
-    auto const &v1 = entry.values.first;
-    auto const &v2 = entry.values.second;
-
-    for (auto const &value : cell.notes().values()) {
-        if (value == v1) continue;
-        if (value == v2) continue;
-
-        mBoard.clear_note_at(cell.coord(), value);
-        std::cout << "[HP] " << cell.coord() << " x" << value << " " << entry << std::endl;
-        did_act = true;
+        // the pair's two cells, addressed by coord (findings carry coords)
+        did_act |= act_on_hidden_pair(board, cell_at(board, hp->coords.first), *hp);
+        did_act |= act_on_hidden_pair(board, cell_at(board, hp->coords.second), *hp);
     }
-
-    return did_act;
-}
-
-bool Analyzer::act_on_hidden_pair() {
-    bool did_act = false;
-
-    if (mHiddenPairs.empty()) return did_act;
-
-    for (auto const &entry : mHiddenPairs) {
-        auto &c1 = mBoard.at(entry.coords.first);
-        auto &c2 = mBoard.at(entry.coords.second);
-
-        did_act |= act_on_hidden_pair(c1, entry);
-        did_act |= act_on_hidden_pair(c2, entry);
-    }
-    mHiddenPairs.clear();
+    mine.clear();
 
     assert(did_act);
     return did_act;
 }
 
-// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp)
-// can link test_hidden_pair<Row> directly. Its only in-TU caller is
-// find_hidden_pair, which at -O3 g++ inlines, emitting no out-of-line copy of
-// the predicate; the external reference from the test TU then fails to link
-// (clang happens to keep a weak definition, so it only bit the gcc build).
-template bool Analyzer::test_hidden_pair<Row>(const Cell &, const Cell &, const Value &, const Value &, const Row &) const;
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::HiddenPair &hp) {
-    return outs << "{" << hp.coords.first << "," << hp.coords.second << "}#{" << hp.values.first << "," << hp.values.second << "}";
-}
+// Explicit instantiation so the whitebox test (tests/unit/test_analyzer.cpp) can
+// link test_hidden_pair<Row> directly. Its only in-TU caller is find_hidden_pair,
+// which at -O3 g++ inlines, emitting no out-of-line copy of the predicate; the
+// external reference from the test TU then fails to link (clang happens to keep a
+// weak definition, so it only bit the gcc build). See docs/test-predicate-idiom.md.
+template bool HiddenPairTechnique::test_hidden_pair<Row>(const Cell &, const Cell &, const Value &, const Value &, const Row &);

--- a/analyzer-hiddenpairs.h
+++ b/analyzer-hiddenpairs.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+#include "cell.h"  // Cell, Value used in the test_hidden_pair contract below
+
+// Hidden pair: two values that, within one unit (row, column, or nonet), appear
+// as candidates in exactly the same two cells and nowhere else in that unit.
+// Those two cells are then locked to that pair, so every other candidate can be
+// stripped from them.
+//
+// Like Naked Pairs, HP is a *hooked* technique: its validation predicate is
+// exercised directly by the whitebox suite. The concrete HiddenPairFinding still
+// lives file-local in the .cpp (the hook tests the predicate, not the finding),
+// but test_hidden_pair is promoted here to a tested public contract -- see below.
+class HiddenPairTechnique : public Technique {
+public:
+    const char *name() const override { return "HP"; }
+    Tier        tier() const override { return Tier::Advanced; }
+    bool  brace_each() const override { return true; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+
+    // Tested contract, NOT a leaked private: is (c1, c2) a genuine, actionable
+    // hidden pair for values (v1, v2) within `set`? The old Analyzer::test_hidden_pair
+    // was reached by a friend hook because techniques weren't standalone; now that
+    // HiddenPairTechnique is standalone this is promoted to a public static so the
+    // whitebox suite judges crafted tuples directly, without friendship (issue #7's
+    // stated payoff). It requires v1 < v2 and c1 before c2: find_ enumerates in that
+    // order, but a direct test caller can pass either way, so the predicate guards
+    // the precondition itself. Templated on the unit type; an explicit Row
+    // instantiation in the .cpp forces an out-of-line symbol so the gcc -O3 cross-TU
+    // reference from the test links (see docs/test-predicate-idiom.md).
+    template<class Set>
+    static bool test_hidden_pair(const Cell &c1, const Cell &c2, const Value &v1, const Value &v2, const Set &set);
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -36,6 +36,7 @@ const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
         r.push_back(std::make_unique<HiddenSingleTechnique>());
         r.push_back(std::make_unique<NakedPairTechnique>());
         r.push_back(std::make_unique<LockedCandidatesTechnique>());
+        r.push_back(std::make_unique<HiddenPairTechnique>());
         assert(r.size() <= std::size(kCascade));
         for (size_t i = 0; i < r.size(); ++i)
             assert(std::string_view(r[i]->name()) == kCascade[i]);
@@ -87,7 +88,6 @@ void Analyzer::analyze() {
     filter_notes();
 
     for (auto &b : mFindings) b.clear();
-    mHiddenPairs.clear();
     mXWings.clear();
     mSwordfish.clear();
     mColorChains.clear();
@@ -106,7 +106,6 @@ void Analyzer::analyze() {
     assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
-    if (!did_find) did_find = find_hidden_pairs();
     if (!did_find) did_find = find_xwings();
     if (!did_find) did_find = find_color_chains();
     if (!did_find) did_find = find_ywings();
@@ -127,7 +126,6 @@ bool Analyzer::act(const bool singles_only) {
     }
 
     if (!singles_only) {
-        if (!did_act) did_act = act_on_hidden_pair();
         if (!did_act) did_act = act_on_xwing();
         if (!did_act) did_act = act_on_color_chain();
         if (!did_act) did_act = act_on_ywing();
@@ -184,7 +182,6 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }
-    print_section(outs, "HP", a.mHiddenPairs,      true);  outs << std::endl;
     print_section(outs, "XW", a.mXWings,           true);  outs << std::endl;
     print_section(outs, "SC", a.mColorChains,      true);  outs << std::endl; // a.k.a. single's chains
     print_section(outs, "YW", a.mYWings,           true);  outs << std::endl;

--- a/analyzer.h
+++ b/analyzer.h
@@ -18,7 +18,6 @@ public:
 
     Analyzer(Board &board, Analyzer const &other)
         : mFindings(other.mFindings)
-        , mHiddenPairs(other.mHiddenPairs)
         , mXWings(other.mXWings)
         , mSwordfish(other.mSwordfish)
         , mColorChains(other.mColorChains)
@@ -70,28 +69,6 @@ private:
     // -Wreorder; the rebinding-ctor regression test guards the one hand-written
     // mFindings(other.mFindings) copy.
     std::vector<FindingList> mFindings;
-
-private:
-    //** hidden pairs
-    struct HiddenPair {
-        std::pair<Coord, Coord> coords;
-        std::pair<Value, Value> values;
-
-        bool operator==(const HiddenPair &other) const = default;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const HiddenPair &);
-    std::vector<HiddenPair> mHiddenPairs;
-
-    // find
-    template<class Set>
-    bool test_hidden_pair(const Cell &, const Cell &, const Value &, const Value &, const Set &) const;
-    template<class Set>
-    bool find_hidden_pair(const Cell &, const Value &v1, const Value &v2, const Set &);
-    bool find_hidden_pairs();
-
-    // act
-    bool act_on_hidden_pair(Cell &, const HiddenPair &);
-    bool act_on_hidden_pair();
 
 private:
     //** x-wing

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -77,12 +77,11 @@ materialized-object) and 3 inline (the 3 scan-fused). The codebase matches:
   is just validation of a given tuple, exactly like naked pair's would-act
   check), and it is extracted to a `test_hidden_pair` mirroring `test_naked_pair`
   (the old hand-rolled `condition_met` / `ppair_cell` single-pass bookkeeping is
-  gone). It is still private to `Analyzer` (not yet ported behind the registry),
-  so its templated predicate is tested directly via a friend hook plus an
-  explicit `Row` instantiation. Naked pair used that same friend-hook route until
-  it ported (issue #7); porting let it promote the predicate to a public `static`
-  member and drop the hook, so hidden pair is now the remaining friend-hook
-  worked example (see "A note on templates" below).
+  gone). It has now ported behind the registry (issue #7), which -- exactly as it
+  did for naked pair -- let its templated predicate promote to a public `static`
+  member of `HiddenPairTechnique` and drop the friend hook; the whitebox suite
+  calls `HiddenPairTechnique::test_hidden_pair` directly, backed by an explicit
+  `Row` instantiation (see "A note on templates" below).
 
 - **X-Wing correctly has no `test_`.** It is scan-fused; PR #24 removed the dead
   predicate and kept `find_xwing` inline, tested through `find_` like its fish
@@ -113,15 +112,18 @@ PR #27 for `test_naked_pair`:
   the test *names* the predicate depends on whether the technique has ported
   behind the registry:
   - **Still private to `Analyzer` (not yet ported):** add a friend hook in
-    `AnalyzerTest` that instantiates the predicate on a concrete unit (e.g.
-    `test_hidden_pair_row` calls `a.test_hidden_pair(c1, c2, v1, v2, a.mBoard.row(c1))`),
-    with `template bool Analyzer::test_hidden_pair<Row>(...) const;` beside the
-    definition.
+    `AnalyzerTest` that instantiates the predicate on a concrete unit (e.g. a
+    `test_foo_row` wrapper calling `a.test_foo(..., a.mBoard.row(c1))`), with
+    `template bool Analyzer::test_foo<Row>(...) const;` beside the definition.
+    No ported technique still uses this route -- naked pair and hidden pair both
+    took it while private and shed it on porting -- but it remains the recipe for
+    any templated predicate that is tested directly before its technique ports.
   - **Ported behind the registry (standalone `Technique`):** the predicate has no
     `Analyzer` to be private to, so promote it to a public `static` member of the
     technique — a documented tested contract — and have the test call it directly,
     no friendship required. Naked pair took this route (issue #7): the test calls
     `NakedPairTechnique::test_naked_pair<Row>(...)` and the friend hook is deleted.
+    Hidden pair took the same route (`HiddenPairTechnique::test_hidden_pair<Row>(...)`).
     Because the member is `static` there is no trailing `const`, and the explicit
     instantiation is likewise unqualified by `Analyzer`:
     `template bool NakedPairTechnique::test_naked_pair<Row>(const Cell &, const Cell &, const Row &);`.
@@ -132,7 +134,8 @@ PR #27 for `test_naked_pair`:
   it through `find_` (cheap, coarser, no link tax), or pay the
   explicit-instantiation tax (plus a friend hook, if the technique is still
   private to `Analyzer`) for direct per-branch predicate tests. Both worked
-  examples, driven from `tests/unit/test_analyzer.cpp`, took the second route:
-  `test_hidden_pair` (`analyzer-hiddenpairs.cpp`) is the friend-hook variant, and
-  `test_naked_pair` (`analyzer-nakedpairs.h` / `analyzer-nakedpairs.cpp`) is the
-  promoted public-static-member variant.
+  examples, driven from `tests/unit/test_analyzer.cpp`, took the second route and
+  are now the promoted public-static-member variant: `test_naked_pair`
+  (`analyzer-nakedpairs.h` / `.cpp`) and `test_hidden_pair`
+  (`analyzer-hiddenpairs.h` / `.cpp`). Both used the friend-hook variant while
+  private to `Analyzer` and shed it on porting (issue #7).

--- a/techniques.h
+++ b/techniques.h
@@ -10,3 +10,4 @@
 #include "analyzer-hiddensingles.h"
 #include "analyzer-nakedpairs.h"
 #include "analyzer-lockedcandidates.h"
+#include "analyzer-hiddenpairs.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -18,6 +18,7 @@
 #include "board.h"
 #include "analyzer.h"
 #include "analyzer-nakedpairs.h"
+#include "analyzer-hiddenpairs.h"
 #include "cell.h"
 #include "coord.h"
 
@@ -106,18 +107,10 @@ struct AnalyzerTest {
     static bool   xwing_row_based(const Analyzer &a)                     { return a.mXWings.at(0).is_row_based; }
     static Value  xwing_value(const Analyzer &a)                         { return a.mXWings.at(0).value; }
 
-    // --- naked pair ---
-    // No hook: NP is ported to a standalone NakedPairTechnique (issue #7), whose
-    // test_naked_pair is a promoted public static -- the whitebox case calls it
-    // directly, without friendship. (HP below still needs a hook until it ports.)
-
-    // --- hidden pair ---
-    // test_hidden_pair is given-tuple shaped too (identity is (c1,c2,v1,v2)):
-    // find_ enumerates the partner, the predicate judges each. Drive it directly
-    // on a crafted Row, the same way as naked pair.
-    static bool test_hidden_pair_row(const Analyzer &a, const Cell &c1, const Cell &c2, const Value &v1, const Value &v2) {
-        return a.test_hidden_pair(c1, c2, v1, v2, a.mBoard.row(c1));
-    }
+    // --- naked pair / hidden pair ---
+    // No hooks: both are ported to standalone Techniques (issue #7), whose
+    // test_naked_pair / test_hidden_pair are promoted public statics -- the
+    // whitebox cases call them directly, without friendship.
 
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
@@ -464,7 +457,9 @@ void test_naked_pair_accept_and_reject() {
 
 // test_hidden_pair is given-tuple shaped like test_naked_pair (see
 // docs/test-predicate-idiom.md): find_ enumerates the partner cell, the
-// predicate judges each (c1,c2,v1,v2). These cases pin down its substantive
+// predicate judges each (c1,c2,v1,v2). Now that HP is ported to a standalone
+// HiddenPairTechnique (issue #7), the predicate is a promoted public static, so
+// these cases call it directly -- no friend hook. They pin down its substantive
 // branches -- value ordering, cell ordering, the hidden loop, actionability,
 // and partner incompleteness -- and leave the trivial distinctness/shape guards
 // (c1 == c2, v1 == v2, set membership, isNote, c1 failing to carry the pair)
@@ -485,18 +480,16 @@ void test_hidden_pair_accept_and_reject() {
     Board board = empty_board();
     confine_value(board, kThree, { {0, 0}, {0, 1} });
     confine_value(board, kFive,  { {0, 0}, {0, 1} });
-    Analyzer analyzer(board);
 
-    check(AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1), kThree, kFive),
+    check(HiddenPairTechnique::test_hidden_pair(cell_at(board, 0, 0), cell_at(board, 0, 1), kThree, kFive, board.row(cell_at(board, 0, 0))),
           "accepted: {3,5} confined to two cells, each with more to strip");
 
     // A third cell in the row carrying just one of the values breaks "hidden".
     Board stray = empty_board();
     confine_value(stray, kThree, { {0, 0}, {0, 1}, {0, 2} });
     confine_value(stray, kFive,  { {0, 0}, {0, 1} });
-    Analyzer stray_analyzer(stray);
 
-    check(!AnalyzerTest::test_hidden_pair_row(stray_analyzer, cell_at(stray, 0, 0), cell_at(stray, 0, 1), kThree, kFive),
+    check(!HiddenPairTechnique::test_hidden_pair(cell_at(stray, 0, 0), cell_at(stray, 0, 1), kThree, kFive, stray.row(cell_at(stray, 0, 0))),
           "rejected: a third cell carries 3, so {3,5} is not hidden");
 
     // --- actionability gate ---
@@ -507,19 +500,18 @@ void test_hidden_pair_accept_and_reject() {
     set_candidates(naked, 0, 1, {3, 5});
     confine_value(naked, kThree, { {0, 0}, {0, 1} });
     confine_value(naked, kFive,  { {0, 0}, {0, 1} });
-    Analyzer naked_analyzer(naked);
 
-    check(!AnalyzerTest::test_hidden_pair_row(naked_analyzer, cell_at(naked, 0, 0), cell_at(naked, 0, 1), kThree, kFive),
+    check(!HiddenPairTechnique::test_hidden_pair(cell_at(naked, 0, 0), cell_at(naked, 0, 1), kThree, kFive, naked.row(cell_at(naked, 0, 0))),
           "rejected: both cells bivalue {3,5} -- a naked pair, nothing to strip");
 
     // --- ordering and partner gates (reuse the accepting board) ---
     // Cell ordering: c2 must come after c1.
-    check(!AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 1), cell_at(board, 0, 0), kThree, kFive),
+    check(!HiddenPairTechnique::test_hidden_pair(cell_at(board, 0, 1), cell_at(board, 0, 0), kThree, kFive, board.row(cell_at(board, 0, 0))),
           "rejected: cells passed out of order (c2 before c1)");
 
-    // Value ordering: v2 must come after v1. find_ guarantees this; the friend
-    // hook can violate it, so the guard must be tested through the hook.
-    check(!AnalyzerTest::test_hidden_pair_row(analyzer, cell_at(board, 0, 0), cell_at(board, 0, 1), kFive, kThree),
+    // Value ordering: v2 must come after v1. find_ guarantees this; a direct
+    // test caller can violate it, so the guard must be tested by the direct call.
+    check(!HiddenPairTechnique::test_hidden_pair(cell_at(board, 0, 0), cell_at(board, 0, 1), kFive, kThree, board.row(cell_at(board, 0, 0))),
           "rejected: values passed out of order (v2 < v1)");
 
     // Partner incompleteness: c2 carries only one of the two values. find_ does
@@ -532,9 +524,8 @@ void test_hidden_pair_accept_and_reject() {
     confine_value(partial, kThree, { {0, 0}, {0, 1} });
     confine_value(partial, kFive,  { {0, 0} });   // 5 lives only in (0,0)
     set_candidates(partial, 0, 1, {3});           // partner carries 3 but not 5
-    Analyzer partial_analyzer(partial);
 
-    check(!AnalyzerTest::test_hidden_pair_row(partial_analyzer, cell_at(partial, 0, 0), cell_at(partial, 0, 1), kThree, kFive),
+    check(!HiddenPairTechnique::test_hidden_pair(cell_at(partial, 0, 0), cell_at(partial, 0, 1), kThree, kFive, partial.row(cell_at(partial, 0, 0))),
           "rejected: partner carries 3 but not 5");
 }
 
@@ -750,8 +741,8 @@ void test_rebinding_ctor_carries_findings() {
 
     Analyzer a(board);
     a.analyze();
-    check(AnalyzerTest::findings_bucket_count(a) == 4, "four registry buckets (NS, HS, NP, LC)");
-    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC short-circuited)");
+    check(AnalyzerTest::findings_bucket_count(a) == 5, "five registry buckets (NS, HS, NP, LC, HP)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC/HP short-circuited)");
 
     // Copy the candidate grid and rebind onto it -- this is the ONLY operation
     // under test. b.analyze() is deliberately never called.

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -467,7 +467,7 @@ void test_naked_pair_accept_and_reject() {
 // also hit incidentally by any black-box solve, since find_hidden_pair feeds
 // every unfiltered cell to the predicate; the one find_ genuinely cannot reach
 // is value ordering
-// (find_hidden_pairs enumerates pv2 = pv1 + 1, so v1 < v2 always holds), which
+// (HiddenPairTechnique::find enumerates pv2 = pv1 + 1, so v1 < v2 always holds), which
 // is the load-bearing reason to test the predicate directly rather than only
 // through find_.
 void test_hidden_pair_accept_and_reject() {


### PR DESCRIPTION
Ports **Hidden Pairs** to the stateless `Technique` registry: the fifth technique in the issue-7 series (NS, HS, NP, LC, **HP**). HP is a *hooked* technique, so it follows the Naked Pairs precedent (PR #40).

## What changed
- **New `analyzer-hiddenpairs.h`** — `HiddenPairTechnique` (name `HP`, tier `Advanced`, `brace_each` true) plus the promoted public-static `test_hidden_pair` predicate (a tested contract, no longer reached by friendship).
- **`analyzer-hiddenpairs.cpp`** — file-local `HiddenPairFinding : Finding`; `find`/`apply` over a `FindingList`; `test_hidden_pair` as a public static with an explicit `Row` instantiation (gcc `-O3` cross-TU link tax, see `docs/test-predicate-idiom.md`). Pair cells are resolved via `board.row(coord)` (a `cell_at` helper) since ported techniques lose `Board::at` friendship.
- **Registry wiring** — `techniques.h` includes the header; `analyzer.cpp` pushes `HiddenPairTechnique` into `registry()` and drops the four HP suffix sites (`mHiddenPairs.clear()`, `find_hidden_pairs()`, `act_on_hidden_pair()`, the HP `print_section` line).
- **`analyzer.h`** — deletes the hidden-pairs member block and the `mHiddenPairs(other.mHiddenPairs)` rebinding-ctor initializer (site 7 shrinks again).
- **Tests** — drop the `test_hidden_pair_row` friend hook, call `HiddenPairTechnique::test_hidden_pair` directly, bump the rebinding-ctor bucket count 4→5 (NS, HS, NP, LC, HP).
- **Docs** — `docs/test-predicate-idiom.md`: HP marked as ported (public-static route, like NP); friend-hook worked-example wording refreshed.

## Verification
- `make` clean (`-Wall -Werror`); `make unit` all pass (incl. the bumped bucket-count assertion); `make test` 80/80.
- Full-transcript byte-diff against the pre-port binary (worktree at `8a9bc84`): **byte-identical** across `P_clm`, `P_hard`, `P_adv`, `P_med` (~1000+ lines each). HP output (`[fHP]` discovery, `[HP](n)` dumps, `[HP] … x…` actions) confirmed present and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)