### PR TITLE
Technique registry: port X-Wing (#7)

### DIFF
--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -1,19 +1,34 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-xwing.h"
 #include "analyzer-util.h"
 #include "board.h"
+#include "row.h"
+#include "column.h"
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
+
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <type_traits>
 
 using analyzer_util::candidates;
 using analyzer_util::line_of;
 
+namespace {
+
+// Find an X-Wing anchored on `cell` for `value`, with `cset` the base line and
+// `eset` the cross line through `cell`; `csets` are all lines parallel to `cset`.
+// Was Analyzer::find_xwing (the templated inner overload); records into the
+// technique's own bucket `out` instead of the member vector. find() stops at the
+// first hit, so out holds at most one entry (asserted below).
 template<class CandidateSet, class EliminationSet>
-bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateSet &cset, const EliminationSet &eset, const std::vector<CandidateSet> &csets, bool by_row) {
+bool find_xwing(const Board &board, const Cell &cell, const Value &value,
+                const CandidateSet &cset, const EliminationSet &eset,
+                const std::vector<CandidateSet> &csets, bool by_row, FindingList &out) {
     assert(cell.isNote());
     assert(cell.check(value));
     assert(cset.contains(cell));
@@ -28,7 +43,7 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
     const Cell& other_cell = cset_candidates[1];
 
     // Get the elimination set for the other cell
-    const EliminationSet &other_eset = line_of<EliminationSet>(mBoard, other_cell);
+    const EliminationSet &other_eset = line_of<EliminationSet>(board, other_cell);
     assert(eset < other_eset);
 
     // yes! for every subsequent cset
@@ -55,48 +70,21 @@ bool Analyzer::find_xwing(const Cell &cell, const Value &value, const CandidateS
         if (anchor_eliminates.size() <= 2 && diagonal_eliminates.size() <= 2) continue;
 
         // yes! record the pattern
-        XWing candidate_xwing{value, cell.coord(), diagonal.coord(), by_row};
-        assert(mXWings.empty());
-        mXWings.push_back(candidate_xwing);
-        if (sVerbose) std::cout << "  [fXW] " << candidate_xwing << std::endl;
+        auto finding = std::make_shared<XWingFinding>(value, cell.coord(), diagonal.coord(), by_row);
+        assert(out.empty());
+        if (sVerbose) { std::cout << "  [fXW] "; finding->print(std::cout); std::cout << std::endl; }
+        out.push_back(finding);
         return true;
     }
 
     return false;
 }
 
-bool Analyzer::find_xwing(const Cell &cell, const Value &value) {
-    assert(cell.isNote());
-    assert(cell.check(value));
-
-    if (find_xwing(cell, value, mBoard.row(cell), mBoard.column(cell), mBoard.rows(), true))
-        return true;
-    return find_xwing(cell, value, mBoard.column(cell), mBoard.row(cell), mBoard.columns(), false);
-}
-
-bool Analyzer::find_xwings() {
-    // https://www.sudokuwiki.org/x_wing_strategy
-    // When there are only two possible cells for a value in each of two different rows,
-    // and these candidates lie also in the same columns, then all other candidates for
-    // this value in the columns can be eliminated.
-    for (auto const &cell: mBoard.cells()) {
-        // is this a note cell?
-        if (!cell.isNote()) continue;
-
-        // for each value in this cell...
-        for (auto const &value : cell.notes().values()) {
-            // let's see if we can anchor an X-Wing pattern in this cell for this value;
-            // stop at the first one found
-            if (find_xwing(cell, value)) return true;
-        }
-    }
-
-    return false;
-}
-
+// Clear `value` from every cell of `eset` that is not one of the pattern's two
+// cross-line cells. Was Analyzer::act_on_xwing (the templated inner overload).
 template<class CandidateSet, class EliminationSet>
-bool Analyzer::act_on_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                                const EliminationSet &eset, Unit unit) {
+bool act_on_xwing(Board &board, const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
+                                                    const EliminationSet &eset, Unit unit) {
     bool did_act = false;
 
     for (auto &cell : eset) {
@@ -107,15 +95,17 @@ bool Analyzer::act_on_xwing(const Value &value, const CandidateSet &cset1, const
         assert(cell.check(value));
 
         std::cout << "[XW] " << cell.coord() << " x" << value << " [" << tag(unit) << "]" << std::endl;
-        mBoard.clear_note_at(cell.coord(), value);
+        board.clear_note_at(cell.coord(), value);
         did_act = true;
     }
 
     return did_act;
 }
 
+// Apply one recorded X-Wing: eliminate strays from both cross lines. Was
+// Analyzer::act_on_xwing(const XWing &).
 template<class EliminationSet>
-bool Analyzer::act_on_xwing(const XWing &entry) {
+bool act_on_xwing(Board &board, const XWingFinding &entry) {
     // The base lines and the elimination lines are always opposite kinds, so
     // derive one from the other rather than letting a caller pass a mismatched
     // pair (e.g. <Row, Row>) that would compile and silently misbehave.
@@ -123,37 +113,69 @@ bool Analyzer::act_on_xwing(const XWing &entry) {
 
     // The two base lines hold the pattern; the two elimination lines are where
     // strays for `value` get cleared. line_of picks row vs column once.
-    auto anchor_candidates   = candidates(line_of<CandidateSet>(mBoard, entry.anchor),   entry.value);
-    auto diagonal_candidates = candidates(line_of<CandidateSet>(mBoard, entry.diagonal), entry.value);
-    auto anchor_eliminates   = candidates(line_of<EliminationSet>(mBoard, entry.anchor),   entry.value);
-    auto diagonal_eliminates = candidates(line_of<EliminationSet>(mBoard, entry.diagonal), entry.value);
+    auto anchor_candidates   = candidates(line_of<CandidateSet>(board, entry.anchor),   entry.value);
+    auto diagonal_candidates = candidates(line_of<CandidateSet>(board, entry.diagonal), entry.value);
+    auto anchor_eliminates   = candidates(line_of<EliminationSet>(board, entry.anchor),   entry.value);
+    auto diagonal_eliminates = candidates(line_of<EliminationSet>(board, entry.diagonal), entry.value);
 
     // `unit` is fully determined by EliminationSet -- derive it, don't thread it.
     constexpr Unit unit = std::is_same_v<EliminationSet, Column> ? Unit::Column : Unit::Row;
 
     bool did_act = false;
-    did_act |= act_on_xwing(entry.value, anchor_candidates, diagonal_candidates, anchor_eliminates, unit);
-    did_act |= act_on_xwing(entry.value, anchor_candidates, diagonal_candidates, diagonal_eliminates, unit);
+    did_act |= act_on_xwing(board, entry.value, anchor_candidates, diagonal_candidates, anchor_eliminates, unit);
+    did_act |= act_on_xwing(board, entry.value, anchor_candidates, diagonal_candidates, diagonal_eliminates, unit);
     return did_act;
 }
 
-bool Analyzer::act_on_xwing() {
-    if (mXWings.empty()) return false;
-    assert(mXWings.size() == 1);
-    auto const entry = mXWings.back();
+} // namespace
+
+bool XWingTechnique::find_xwing(const Board &board, const Cell &cell, const Value &value, FindingList &out) const {
+    assert(cell.isNote());
+    assert(cell.check(value));
+
+    if (::find_xwing(board, cell, value, board.row(cell), board.column(cell), board.rows(), true, out))
+        return true;
+    return ::find_xwing(board, cell, value, board.column(cell), board.row(cell), board.columns(), false, out);
+}
+
+// https://www.sudokuwiki.org/x_wing_strategy
+// When there are only two possible cells for a value in each of two different rows,
+// and these candidates lie also in the same columns, then all other candidates for
+// this value in the columns can be eliminated.
+bool XWingTechnique::find(const Board &board, FindingList &out) const {
+    assert(out.empty());
+
+    for (auto const &cell: board.cells()) {
+        // is this a note cell?
+        if (!cell.isNote()) continue;
+
+        // for each value in this cell...
+        for (auto const &value : cell.notes().values()) {
+            // let's see if we can anchor an X-Wing pattern in this cell for this value;
+            // stop at the first one found
+            if (find_xwing(board, cell, value, out)) return true;
+        }
+    }
+
+    return false;
+}
+
+bool XWingTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
+    assert(mine.size() == 1);
+
+    // Bucket invariant: every entry in this technique's bucket is an XWingFinding
+    // (see NakedSingleTechnique::apply). The assert turns a wrong-bucket wiring
+    // bug into a caught error, not UB.
+    assert(dynamic_cast<const XWingFinding *>(mine.front().get()));
+    auto const *xw = static_cast<const XWingFinding *>(mine.front().get());
 
     // Row-based pattern eliminates from columns; column-based, from rows.
-    bool did_act = entry.is_row_based
-        ? act_on_xwing<Column>(entry)
-        : act_on_xwing<Row>(entry);
+    bool did_act = xw->is_row_based
+        ? act_on_xwing<Column>(board, *xw)
+        : act_on_xwing<Row>(board, *xw);
 
-    mXWings.clear();
+    mine.clear();
     assert(did_act);
     return did_act;
-}
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::XWing &xw) {
-    outs << "{" << xw.anchor << "," << xw.diagonal << "}"
-         << "#" << xw.value << "[^" << (xw.is_row_based ? "c" : "r") << "]";
-    return outs;
 }

--- a/analyzer-xwing.cpp
+++ b/analyzer-xwing.cpp
@@ -129,7 +129,7 @@ bool act_on_xwing(Board &board, const XWingFinding &entry) {
 
 } // namespace
 
-bool XWingTechnique::find_xwing(const Board &board, const Cell &cell, const Value &value, FindingList &out) const {
+bool XWingTechnique::find_xwing(const Board &board, const Cell &cell, const Value &value, FindingList &out) {
     assert(cell.isNote());
     assert(cell.check(value));
 

--- a/analyzer-xwing.h
+++ b/analyzer-xwing.h
@@ -26,10 +26,8 @@ struct XWingFinding : Finding {
 
     XWingFinding(Value v, Coord a, Coord d, bool row_based)
         : value(v), anchor(a), diagonal(d), is_row_based(row_based) { }
-    bool same(const XWingFinding &o) const {
-        return value == o.value && anchor == o.anchor
-            && diagonal == o.diagonal && is_row_based == o.is_row_based;
-    }
+    // No same()/dedup here (unlike NP/HP/LC): find() short-circuits at the first
+    // hit, so a bucket never holds two X-Wings to compare.
     // Byte-for-byte the old free operator<<(ostream, Analyzer::XWing):
     // "{anchor,diagonal}#value[^c]" (c if row-based, r if column-based).
     void print(std::ostream &o) const override {
@@ -52,8 +50,9 @@ public:
     // there is no test_ predicate to call directly (see docs/test-predicate-idiom.md);
     // the tests instead anchor find_xwing on a chosen cell -- exercising both
     // orientations, the canonical-first-candidate bail, and the rejection paths a
-    // happy-path solve never isolates. Public so the whitebox suite calls it
-    // without friendship (issue #7's stated payoff), mirroring how the promoted
-    // predicates work for the given-tuple techniques.
-    bool find_xwing(const Board &, const Cell &, const Value &, FindingList &out) const;
+    // happy-path solve never isolates. Public *static* so the whitebox suite calls
+    // it without friendship *and* without an instance (issue #7's stated payoff),
+    // matching the promoted-static shape of the given-tuple predicates: the
+    // technique is stateless and this touches no instance data.
+    static bool find_xwing(const Board &, const Cell &, const Value &, FindingList &out);
 };

--- a/analyzer-xwing.h
+++ b/analyzer-xwing.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+#include "coord.h"
+#include "cell.h"  // Value
+
+// X-Wing: for one value, two base lines (both rows, or both columns) that each
+// hold exactly two candidates for that value, and those candidates share the
+// same two cross lines. Every other candidate for the value on those two cross
+// lines can then be eliminated.
+//
+// X-Wing is *scan-fused* (see docs/test-predicate-idiom.md): the pattern's
+// membership emerges only from the validating scan, so there is no separable
+// test_ predicate to promote -- the whitebox suite drives the per-anchor search
+// directly and inspects the recorded finding. That is why XWingFinding lives in
+// this header rather than file-local in the .cpp (unlike NS/HS/NP/LC/HP, whose
+// findings the tests never name): the scan-fused seam needs to read the
+// finding's fields, so the type must be visible to tests/unit/test_analyzer.cpp.
+struct XWingFinding : Finding {
+    Value value;
+    Coord anchor;       // top-left corner of the X-Wing pattern
+    Coord diagonal;     // bottom-right corner of the X-Wing pattern
+    bool is_row_based;  // true if rows hold the pattern, false if columns do
+
+    XWingFinding(Value v, Coord a, Coord d, bool row_based)
+        : value(v), anchor(a), diagonal(d), is_row_based(row_based) { }
+    bool same(const XWingFinding &o) const {
+        return value == o.value && anchor == o.anchor
+            && diagonal == o.diagonal && is_row_based == o.is_row_based;
+    }
+    // Byte-for-byte the old free operator<<(ostream, Analyzer::XWing):
+    // "{anchor,diagonal}#value[^c]" (c if row-based, r if column-based).
+    void print(std::ostream &o) const override {
+        o << "{" << anchor << "," << diagonal << "}"
+          << "#" << value << "[^" << (is_row_based ? "c" : "r") << "]";
+    }
+};
+
+class XWingTechnique : public Technique {
+public:
+    const char *name() const override { return "XW"; }
+    Tier        tier() const override { return Tier::Advanced; }
+    bool  brace_each() const override { return true; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+
+    // Whitebox seam, NOT a leaked private: drive the per-anchor search on a
+    // crafted board and inspect the finding it records. X-Wing is scan-fused, so
+    // there is no test_ predicate to call directly (see docs/test-predicate-idiom.md);
+    // the tests instead anchor find_xwing on a chosen cell -- exercising both
+    // orientations, the canonical-first-candidate bail, and the rejection paths a
+    // happy-path solve never isolates. Public so the whitebox suite calls it
+    // without friendship (issue #7's stated payoff), mirroring how the promoted
+    // predicates work for the given-tuple techniques.
+    bool find_xwing(const Board &, const Cell &, const Value &, FindingList &out) const;
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -37,6 +37,7 @@ const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
         r.push_back(std::make_unique<NakedPairTechnique>());
         r.push_back(std::make_unique<LockedCandidatesTechnique>());
         r.push_back(std::make_unique<HiddenPairTechnique>());
+        r.push_back(std::make_unique<XWingTechnique>());
         assert(r.size() <= std::size(kCascade));
         for (size_t i = 0; i < r.size(); ++i)
             assert(std::string_view(r[i]->name()) == kCascade[i]);
@@ -88,7 +89,6 @@ void Analyzer::analyze() {
     filter_notes();
 
     for (auto &b : mFindings) b.clear();
-    mXWings.clear();
     mSwordfish.clear();
     mColorChains.clear();
     mYWings.clear();
@@ -106,7 +106,6 @@ void Analyzer::analyze() {
     assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
-    if (!did_find) did_find = find_xwings();
     if (!did_find) did_find = find_color_chains();
     if (!did_find) did_find = find_ywings();
     if (!did_find) did_find = find_swordfish();
@@ -126,7 +125,6 @@ bool Analyzer::act(const bool singles_only) {
     }
 
     if (!singles_only) {
-        if (!did_act) did_act = act_on_xwing();
         if (!did_act) did_act = act_on_color_chain();
         if (!did_act) did_act = act_on_ywing();
         if (!did_act) did_act = act_on_swordfish();
@@ -182,7 +180,6 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }
-    print_section(outs, "XW", a.mXWings,           true);  outs << std::endl;
     print_section(outs, "SC", a.mColorChains,      true);  outs << std::endl; // a.k.a. single's chains
     print_section(outs, "YW", a.mYWings,           true);  outs << std::endl;
     print_section(outs, "SF", a.mSwordfish,        true);  outs << std::endl;

--- a/analyzer.h
+++ b/analyzer.h
@@ -18,7 +18,6 @@ public:
 
     Analyzer(Board &board, Analyzer const &other)
         : mFindings(other.mFindings)
-        , mXWings(other.mXWings)
         , mSwordfish(other.mSwordfish)
         , mColorChains(other.mColorChains)
         , mYWings(other.mYWings)
@@ -69,33 +68,6 @@ private:
     // -Wreorder; the rebinding-ctor regression test guards the one hand-written
     // mFindings(other.mFindings) copy.
     std::vector<FindingList> mFindings;
-
-private:
-    //** x-wing
-    struct XWing {
-        Value value;
-        Coord anchor;       // top-left corner of the XWing pattern
-        Coord diagonal;     // bottom-right corner of the XWing pattern
-        bool is_row_based;  // true if rows contain the pattern, false if columns contain the pattern
-
-        bool operator==(const XWing &other) const = default;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const XWing &);
-    std::vector<XWing> mXWings;
-
-    // find
-    template<class CandidateSet, class EliminationSet>
-    bool find_xwing(const Cell &, const Value &, const CandidateSet &, const EliminationSet &, const std::vector<CandidateSet> &, bool by_row);
-    bool find_xwing(const Cell &, const Value &);
-    bool find_xwings();
-
-    // act
-    template<class CandidateSet, class EliminationSet>
-    bool act_on_xwing(const Value &value, const CandidateSet &cset1, const CandidateSet &cset2,
-                                          const EliminationSet &eset, Unit unit);
-    template<class EliminationSet>
-    bool act_on_xwing(const XWing &entry);
-    bool act_on_xwing();
 
 private:
     //** swordfish

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -88,8 +88,10 @@ materialized-object) and 3 inline (the 3 scan-fused). The codebase matches:
   sibling Swordfish. This is the rule working as intended, not a coverage gap. It
   has now ported behind the registry (issue #7). Because it is scan-fused there
   is no predicate to promote, so its whitebox seam differs from the given-tuple
-  techniques: instead of a public `static` predicate, `XWingTechnique::find_xwing`
-  (the per-anchor entry) is a public member the test drives directly, and the
+  techniques: instead of a promoted `test_` predicate, the per-anchor entry
+  `XWingTechnique::find_xwing` is promoted to a public `static` the test drives
+  directly (static because the technique is stateless and the entry touches no
+  instance data -- the same reason the given-tuple predicates are static), and the
   concrete `XWingFinding` is declared in `analyzer-xwing.h` rather than file-local
   so the test can inspect the recorded pattern's orientation and value. This is
   the *scan-fused* seam shape (finding-in-header + public `find_`), distinct from

--- a/docs/test-predicate-idiom.md
+++ b/docs/test-predicate-idiom.md
@@ -85,7 +85,17 @@ materialized-object) and 3 inline (the 3 scan-fused). The codebase matches:
 
 - **X-Wing correctly has no `test_`.** It is scan-fused; PR #24 removed the dead
   predicate and kept `find_xwing` inline, tested through `find_` like its fish
-  sibling Swordfish. This is the rule working as intended, not a coverage gap.
+  sibling Swordfish. This is the rule working as intended, not a coverage gap. It
+  has now ported behind the registry (issue #7). Because it is scan-fused there
+  is no predicate to promote, so its whitebox seam differs from the given-tuple
+  techniques: instead of a public `static` predicate, `XWingTechnique::find_xwing`
+  (the per-anchor entry) is a public member the test drives directly, and the
+  concrete `XWingFinding` is declared in `analyzer-xwing.h` rather than file-local
+  so the test can inspect the recorded pattern's orientation and value. This is
+  the *scan-fused* seam shape (finding-in-header + public `find_`), distinct from
+  the *given-tuple* seam (promoted `test_` predicate, finding stays file-local);
+  the finding is exposed exactly when the test must read its fields, not merely
+  because the technique is hooked. Either way the friend hook is gone.
 
 - **Locked candidates and Swordfish correctly inline.** Both are scan-fused; a
   `test_` for either would hit the out-param / re-derivation smell above.

--- a/techniques.h
+++ b/techniques.h
@@ -11,3 +11,4 @@
 #include "analyzer-nakedpairs.h"
 #include "analyzer-lockedcandidates.h"
 #include "analyzer-hiddenpairs.h"
+#include "analyzer-xwing.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -19,6 +19,7 @@
 #include "analyzer.h"
 #include "analyzer-nakedpairs.h"
 #include "analyzer-hiddenpairs.h"
+#include "analyzer-xwing.h"
 #include "cell.h"
 #include "coord.h"
 
@@ -98,19 +99,14 @@ struct AnalyzerTest {
     static size_t ywing_count(const Analyzer &a)                                                   { return a.mYWings.size(); }
     static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
 
-    // --- x-wing ---
-    // find_xwing validates inline (like find_swordfish), so drive it on crafted
-    // boards through its anchor entry point and inspect the recorded result.
-    static bool   find_xwing(Analyzer &a, const Cell &c, const Value &v) { return a.find_xwing(c, v); }
-    static bool   act_on_xwing(Analyzer &a)                              { return a.act_on_xwing(); }
-    static size_t xwing_count(const Analyzer &a)                         { return a.mXWings.size(); }
-    static bool   xwing_row_based(const Analyzer &a)                     { return a.mXWings.at(0).is_row_based; }
-    static Value  xwing_value(const Analyzer &a)                         { return a.mXWings.at(0).value; }
-
-    // --- naked pair / hidden pair ---
-    // No hooks: both are ported to standalone Techniques (issue #7), whose
-    // test_naked_pair / test_hidden_pair are promoted public statics -- the
-    // whitebox cases call them directly, without friendship.
+    // --- x-wing / naked pair / hidden pair ---
+    // No hooks: all three are ported to standalone Techniques (issue #7). Naked
+    // pair and hidden pair are given-tuple shaped, so their test_naked_pair /
+    // test_hidden_pair are promoted public statics the whitebox cases call
+    // directly. X-Wing is scan-fused (no test_ predicate -- see
+    // docs/test-predicate-idiom.md); the cases drive XWingTechnique::find_xwing
+    // on crafted boards and inspect the recorded XWingFinding (visible via
+    // analyzer-xwing.h). Either way: no friendship.
 
     // --- simple coloring ---
     static bool test_color_chain(const Analyzer &a, const Analyzer::ColorChain &ch) { return a.test_color_chain(ch); }
@@ -533,11 +529,22 @@ void test_hidden_pair_accept_and_reject() {
 // X-Wing
 // ===========================================================================
 
-// find_xwing validates inline. The black-box suite drives it on real solves;
-// these whitebox cases craft small boards and drive find_xwing through its
-// anchor entry point -- the same way the Swordfish tests drive find_swordfish --
-// to cover both orientations and the rejection paths a happy-path solve does not
-// isolate.
+// X-Wing is scan-fused (no test_ predicate -- see docs/test-predicate-idiom.md).
+// The black-box suite drives it on real solves; these whitebox cases craft small
+// boards and drive XWingTechnique::find_xwing through its anchor entry point --
+// the same way the Swordfish tests drive find_swordfish -- to cover both
+// orientations and the rejection paths a happy-path solve does not isolate. Since
+// there is no predicate to inspect, they read the recorded XWingFinding's fields
+// directly (the finding type is visible via analyzer-xwing.h, the seam that
+// replaces the old AnalyzerTest hook -- no friendship needed, issue #7's payoff).
+
+// The lone XWingFinding recorded in `out`, or nullptr if the search recorded
+// something other than exactly one finding. Downcasts within the technique's own
+// bucket, so every entry is an XWingFinding by construction.
+const XWingFinding *only_xwing(const FindingList &out) {
+    if (out.size() != 1) return nullptr;
+    return dynamic_cast<const XWingFinding *>(out.front().get());
+}
 
 // A row-based X-Wing on value 7: rows 0 and 3 each hold 7 in exactly columns 1
 // and 5. Columns 1 and 5 carry one extra 7 apiece (rows 6 and 7), so the pattern
@@ -554,18 +561,18 @@ void test_xwing_row_based() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
-    Analyzer analyzer(board);
+    XWingTechnique xw;
+    FindingList found;
     // Anchor on (0,1), the first 7 of row 0 -- find_xwing's top-left corner.
-    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
-    check(found, "row X-Wing detected with anchor (0,1)");
-    check(AnalyzerTest::xwing_count(analyzer) == 1, "exactly one X-Wing recorded");
-    if (AnalyzerTest::xwing_count(analyzer) == 1) {
-        check(AnalyzerTest::xwing_row_based(analyzer), "recorded X-Wing is row-based");
-        check(AnalyzerTest::xwing_value(analyzer) == V, "recorded X-Wing is for value 7");
+    check(xw.find_xwing(board, cell_at(board, 0, 1), V, found), "row X-Wing detected with anchor (0,1)");
+    check(found.size() == 1, "exactly one X-Wing recorded");
+    if (auto const *f = only_xwing(found)) {
+        check(f->is_row_based, "recorded X-Wing is row-based");
+        check(f->value == V, "recorded X-Wing is for value 7");
     }
 
-    bool acted = AnalyzerTest::act_on_xwing(analyzer);
-    check(acted, "act_on_xwing reports an elimination");
+    bool acted = xw.apply(board, found);
+    check(acted, "apply reports an elimination");
     check(!has_candidate(board, 6, 1, V), "stray 7 at (6,1) eliminated from column 1");
     check(!has_candidate(board, 7, 5, V), "stray 7 at (7,5) eliminated from column 5");
     check(has_candidate(board, 0, 1, V) && has_candidate(board, 0, 5, V)
@@ -587,17 +594,17 @@ void test_xwing_column_based() {
     const Value V = kSeven;
     confine_value(board, V, { {1,0},{5,0}, {1,3},{5,3}, {1,6}, {5,7} });
 
-    Analyzer analyzer(board);
-    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 1, 0), V);
-    check(found, "column X-Wing detected with anchor (1,0)");
-    check(AnalyzerTest::xwing_count(analyzer) == 1, "exactly one X-Wing recorded");
-    if (AnalyzerTest::xwing_count(analyzer) == 1) {
-        check(!AnalyzerTest::xwing_row_based(analyzer), "recorded X-Wing is column-based");
-        check(AnalyzerTest::xwing_value(analyzer) == V, "recorded X-Wing is for value 7");
+    XWingTechnique xw;
+    FindingList found;
+    check(xw.find_xwing(board, cell_at(board, 1, 0), V, found), "column X-Wing detected with anchor (1,0)");
+    check(found.size() == 1, "exactly one X-Wing recorded");
+    if (auto const *f = only_xwing(found)) {
+        check(!f->is_row_based, "recorded X-Wing is column-based");
+        check(f->value == V, "recorded X-Wing is for value 7");
     }
 
-    bool acted = AnalyzerTest::act_on_xwing(analyzer);
-    check(acted, "act_on_xwing reports an elimination");
+    bool acted = xw.apply(board, found);
+    check(acted, "apply reports an elimination");
     check(!has_candidate(board, 1, 6, V), "stray 7 at (1,6) eliminated from row 1");
     check(!has_candidate(board, 5, 7, V), "stray 7 at (5,7) eliminated from row 5");
     check(has_candidate(board, 1, 0, V) && has_candidate(board, 5, 0, V)
@@ -606,7 +613,7 @@ void test_xwing_column_based() {
 }
 
 // A perfect rectangle with nothing to eliminate must not be recorded (recording
-// it would assert in act). Rows 0 and 3 hold 7 in columns 1 and 5 and nowhere
+// it would assert in apply). Rows 0 and 3 hold 7 in columns 1 and 5 and nowhere
 // else, so neither column carries a third candidate.
 void test_xwing_no_elimination() {
     std::cout << "[x-wing] a rectangle with nothing to eliminate is not recorded\n";
@@ -614,10 +621,11 @@ void test_xwing_no_elimination() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5} });
 
-    Analyzer analyzer(board);
-    bool found = AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V);
-    check(!found, "no X-Wing reported when there is nothing to eliminate");
-    check(AnalyzerTest::xwing_count(analyzer) == 0, "no X-Wing recorded");
+    XWingTechnique xw;
+    FindingList found;
+    check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
+          "no X-Wing reported when there is nothing to eliminate");
+    check(found.empty(), "no X-Wing recorded");
 }
 
 // Near-misses: the partner row shares only one of the anchor's two columns, so
@@ -633,10 +641,11 @@ void test_xwing_misaligned_not_found() {
     {
         Board board = empty_board();
         confine_value(board, V, { {0,1},{0,5}, {3,1},{3,8}, {7,5} });
-        Analyzer analyzer(board);
-        check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V),
+        XWingTechnique xw;
+        FindingList found;
+        check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
               "no X-Wing when the partner's second candidate is off the rectangle");
-        check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded");
+        check(found.empty(), "nothing recorded");
     }
 
     // Partner's FIRST candidate is off the rectangle: row 0 in cols 1,5; row 3 in
@@ -644,16 +653,17 @@ void test_xwing_misaligned_not_found() {
     {
         Board board = empty_board();
         confine_value(board, V, { {0,1},{0,5}, {3,2},{3,5} });
-        Analyzer analyzer(board);
-        check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 1), V),
+        XWingTechnique xw;
+        FindingList found;
+        check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
               "no X-Wing when the partner's first candidate is off the rectangle");
-        check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded");
+        check(found.empty(), "nothing recorded");
     }
 }
 
 // find_xwing canonicalises on the first candidate of the anchor's line: anchored
 // on a line's *second* candidate it bails at once (a row X-Wing is recorded only
-// when anchored on its first candidate, so find_xwings never double-records it).
+// when anchored on its first candidate, so find() never double-records it).
 // Same board as the row-based test, which finds the pattern from (0,1); from
 // (0,5) it must find nothing.
 void test_xwing_anchor_not_first() {
@@ -662,10 +672,11 @@ void test_xwing_anchor_not_first() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
-    Analyzer analyzer(board);
-    check(!AnalyzerTest::find_xwing(analyzer, cell_at(board, 0, 5), V),
+    XWingTechnique xw;
+    FindingList found;
+    check(!xw.find_xwing(board, cell_at(board, 0, 5), V, found),
           "no X-Wing reported when anchored on the row's second candidate");
-    check(AnalyzerTest::xwing_count(analyzer) == 0, "nothing recorded from the non-first anchor");
+    check(found.empty(), "nothing recorded from the non-first anchor");
 }
 
 // ===========================================================================
@@ -741,8 +752,8 @@ void test_rebinding_ctor_carries_findings() {
 
     Analyzer a(board);
     a.analyze();
-    check(AnalyzerTest::findings_bucket_count(a) == 5, "five registry buckets (NS, HS, NP, LC, HP)");
-    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC/HP short-circuited)");
+    check(AnalyzerTest::findings_bucket_count(a) == 6, "six registry buckets (NS, HS, NP, LC, HP, XW)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC/HP/XW short-circuited)");
 
     // Copy the candidate grid and rebind onto it -- this is the ONLY operation
     // under test. b.analyze() is deliberately never called.

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -561,10 +561,10 @@ void test_xwing_row_based() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
-    XWingTechnique xw;
+    XWingTechnique xw;  // needed for apply() below; find_xwing is static
     FindingList found;
     // Anchor on (0,1), the first 7 of row 0 -- find_xwing's top-left corner.
-    check(xw.find_xwing(board, cell_at(board, 0, 1), V, found), "row X-Wing detected with anchor (0,1)");
+    check(XWingTechnique::find_xwing(board, cell_at(board, 0, 1), V, found), "row X-Wing detected with anchor (0,1)");
     check(found.size() == 1, "exactly one X-Wing recorded");
     if (auto const *f = only_xwing(found)) {
         check(f->is_row_based, "recorded X-Wing is row-based");
@@ -594,9 +594,9 @@ void test_xwing_column_based() {
     const Value V = kSeven;
     confine_value(board, V, { {1,0},{5,0}, {1,3},{5,3}, {1,6}, {5,7} });
 
-    XWingTechnique xw;
+    XWingTechnique xw;  // needed for apply() below; find_xwing is static
     FindingList found;
-    check(xw.find_xwing(board, cell_at(board, 1, 0), V, found), "column X-Wing detected with anchor (1,0)");
+    check(XWingTechnique::find_xwing(board, cell_at(board, 1, 0), V, found), "column X-Wing detected with anchor (1,0)");
     check(found.size() == 1, "exactly one X-Wing recorded");
     if (auto const *f = only_xwing(found)) {
         check(!f->is_row_based, "recorded X-Wing is column-based");
@@ -621,9 +621,8 @@ void test_xwing_no_elimination() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5} });
 
-    XWingTechnique xw;
     FindingList found;
-    check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
+    check(!XWingTechnique::find_xwing(board, cell_at(board, 0, 1), V, found),
           "no X-Wing reported when there is nothing to eliminate");
     check(found.empty(), "no X-Wing recorded");
 }
@@ -641,9 +640,8 @@ void test_xwing_misaligned_not_found() {
     {
         Board board = empty_board();
         confine_value(board, V, { {0,1},{0,5}, {3,1},{3,8}, {7,5} });
-        XWingTechnique xw;
         FindingList found;
-        check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
+        check(!XWingTechnique::find_xwing(board, cell_at(board, 0, 1), V, found),
               "no X-Wing when the partner's second candidate is off the rectangle");
         check(found.empty(), "nothing recorded");
     }
@@ -653,9 +651,8 @@ void test_xwing_misaligned_not_found() {
     {
         Board board = empty_board();
         confine_value(board, V, { {0,1},{0,5}, {3,2},{3,5} });
-        XWingTechnique xw;
         FindingList found;
-        check(!xw.find_xwing(board, cell_at(board, 0, 1), V, found),
+        check(!XWingTechnique::find_xwing(board, cell_at(board, 0, 1), V, found),
               "no X-Wing when the partner's first candidate is off the rectangle");
         check(found.empty(), "nothing recorded");
     }
@@ -672,9 +669,8 @@ void test_xwing_anchor_not_first() {
     const Value V = kSeven;
     confine_value(board, V, { {0,1},{0,5}, {3,1},{3,5}, {6,1}, {7,5} });
 
-    XWingTechnique xw;
     FindingList found;
-    check(!xw.find_xwing(board, cell_at(board, 0, 5), V, found),
+    check(!XWingTechnique::find_xwing(board, cell_at(board, 0, 5), V, found),
           "no X-Wing reported when anchored on the row's second candidate");
     check(found.empty(), "nothing recorded from the non-first anchor");
 }


### PR DESCRIPTION
Move X-Wing out of the `Analyzer` god-class into a standalone `XWingTechnique` in the ordered registry, sixth in cascade order after NS, HS, NP, LC and HP. Deletes X-Wing's entries from the hand-synchronized sites (struct/member/decls in `analyzer.h`, the clear/find/act cascade lines and the `operator<<` line in `analyzer.cpp`) and the rebinding-ctor initializer; the registry loops now drive it.

## Scan-fused seam (the notable departure from prior ports)

X-Wing is **scan-fused** (`docs/test-predicate-idiom.md`): its membership emerges only from the validating scan, so there is no `test_` predicate to promote (unlike the given-tuple NP/HP). Its whitebox seam is therefore a different shape:

- `XWingTechnique::find_xwing` (the per-anchor entry) is a **public member** the tests drive directly.
- the concrete `XWingFinding` is declared in `analyzer-xwing.h` — **not file-local** like the prior five findings — so the tests can inspect the recorded pattern's orientation and value.

Either way the `AnalyzerTest` friend hook is gone. `Finding::print()` reproduces the old free `operator<<` byte-for-byte: `{anchor,diagonal}#value[^c]`.

`find`/`apply` operate on the passed-in `Board` via the public `row`/`column`/`rows`/`columns` accessors and address cells by coord, so Board's friendship with Analyzer is no longer needed here.

## Twin rule

X-Wing and Swordfish are structural fish twins, but the twin rule governs *algorithm* symmetry — preserved here: the fish scan is untouched and the shared helpers in `analyzer-util.h` (`candidates`, `line_of`) stay shared with the not-yet-ported Swordfish. The registry migration is orthogonal plumbing staged one-per-PR in cascade order (XW before SF). Swordfish is the next PR and restores full symmetry.

The rebinding-ctor whitebox test's hardcoded bucket count goes 5 → 6 (NS, HS, NP, LC, HP, XW).

## Verification

- `make unit` + `make test` (80/0) green.
- Full REPL transcripts byte-identical to the pre-port binary across six fixtures (P_easy, P_med, P_clm, P_adv, P_hard, P_sf); P_clm and P_hard exercise real X-Wing finds + eliminations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)