### PR TITLE
Technique registry: port Y-Wing (#7)

### DIFF
--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -1,12 +1,19 @@
 // Copyright (c) 2025, Bertrand Mollinier Toublet
 // See LICENSE for details of BSD 3-Clause License
 
-#include "analyzer.h"
+#include "analyzer-ywing.h"
 #include "board.h"
+#include "row.h"
+#include "column.h"
+#include "nonet.h"
+#include "cell.h"
+#include "coord.h"
 #include "verbose.h"
-#include <algorithm>
+
 #include <iterator>
 #include <cassert>
+#include <memory>
+#include <optional>
 #include <unordered_set>
 
 namespace { // anon
@@ -40,51 +47,7 @@ namespace { // anon
 
         return would_act;
     }
-}
 
-bool Analyzer::test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value) const {
-    // by construct, all these assertions apply for input parameters
-    assert(pivot != wing1);
-    assert(pivot != wing2);
-    assert(wing1 != wing2);
-
-    assert(pivot.isNote());
-    assert(wing1.isNote());
-    assert(wing2.isNote());
-
-    assert(pivot.notes().count() == 2);
-    assert(wing1.notes().count() == 2);
-    assert(wing2.notes().count() == 2);
-
-    assert(mBoard.see_each_other(pivot, wing1));
-    assert(mBoard.see_each_other(pivot, wing2));
-
-    // by construct (select_wing_candidates), each wing shares exactly one value
-    // with the pivot: candidates with no value in common with the pivot are
-    // skipped (at least one shared), and candidates with the identical 2-value
-    // set as the pivot are skipped (no more than one shared).
-
-    // which value does each wing share with pivot? By construction exactly one,
-    // so this is the single bit in each wing's intersection with the pivot.
-    Value wing1_shared = wing1.notes().shared_value(pivot.notes());
-    Value wing2_shared = wing2.notes().shared_value(pivot.notes());
-
-    // yes! but do wing1 and wing2 share different values with pivot?
-    if (wing1_shared == wing2_shared) return false;
-
-    // Find the elimination candidate (the candidate that both wings have but pivot doesn't)
-    Value wing1_other = wing1.other_value(wing1_shared);
-    Value wing2_other = wing2.other_value(wing2_shared);
-    if (wing1_other != wing2_other) return false;
-
-    out_value = wing1_other;
-
-    if (!would_act(mBoard, pivot, wing1, wing2, wing1_other)) return false;
-
-    return true;
-}
-
-namespace {
     template<class Set>
     void select_wing_candidates(const Cell &pivot, const Set &set, std::unordered_set<Cell> &wing_candidates) {
         assert(set.contains(pivot));
@@ -111,9 +74,76 @@ namespace {
             wing_candidates.insert(cell);
         }
     }
+
+    // Apply one recorded Y-Wing to one `wing1_set`: clear `value` from every cell
+    // of that set that also sees wing2. Was Analyzer::act_on_ywing(entry, set); the
+    // board is now the passed reference, and cells are addressed by coord (findings
+    // carry coords) rather than resolved through the friends-only Board::at.
+    template <class Set>
+    bool act_on_ywing(Board &board, const YWingFinding &entry, const Set &wing1_set) {
+        bool did_act = false;
+
+        for (auto const &cell : wing1_set) {
+            if (cell.isValue()) continue;
+            if (cell.coord() == entry.pivot) continue;
+            if (cell.coord() == entry.wings.first) continue;
+            if (cell.coord() == entry.wings.second) continue;
+            if (!cell.check(entry.value)) continue;
+
+            if (board.see_each_other(cell.coord(), entry.wings.second)) {
+                std::cout << "[YW] " << cell.coord() << " x" << entry.value << std::endl;
+                board.clear_note_at(cell.coord(), entry.value);
+                did_act = true;
+            }
+        }
+
+        return did_act;
+    }
+} // namespace
+
+bool YWingTechnique::test_ywing(const Board &board, const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value) {
+    // by construct, all these assertions apply for input parameters
+    assert(pivot != wing1);
+    assert(pivot != wing2);
+    assert(wing1 != wing2);
+
+    assert(pivot.isNote());
+    assert(wing1.isNote());
+    assert(wing2.isNote());
+
+    assert(pivot.notes().count() == 2);
+    assert(wing1.notes().count() == 2);
+    assert(wing2.notes().count() == 2);
+
+    assert(board.see_each_other(pivot, wing1));
+    assert(board.see_each_other(pivot, wing2));
+
+    // by construct (select_wing_candidates), each wing shares exactly one value
+    // with the pivot: candidates with no value in common with the pivot are
+    // skipped (at least one shared), and candidates with the identical 2-value
+    // set as the pivot are skipped (no more than one shared).
+
+    // which value does each wing share with pivot? By construction exactly one,
+    // so this is the single bit in each wing's intersection with the pivot.
+    Value wing1_shared = wing1.notes().shared_value(pivot.notes());
+    Value wing2_shared = wing2.notes().shared_value(pivot.notes());
+
+    // yes! but do wing1 and wing2 share different values with pivot?
+    if (wing1_shared == wing2_shared) return false;
+
+    // Find the elimination candidate (the candidate that both wings have but pivot doesn't)
+    Value wing1_other = wing1.other_value(wing1_shared);
+    Value wing2_other = wing2.other_value(wing2_shared);
+    if (wing1_other != wing2_other) return false;
+
+    out_value = wing1_other;
+
+    if (!would_act(board, pivot, wing1, wing2, wing1_other)) return false;
+
+    return true;
 }
 
-bool Analyzer::find_ywing(const Cell &pivot) {
+bool YWingTechnique::find_ywing(const Board &board, const Cell &pivot, FindingList &out) {
     assert(pivot.isNote());
     assert(pivot.notes().count() == 2);
 
@@ -121,9 +151,9 @@ bool Analyzer::find_ywing(const Cell &pivot) {
 
     // Get all cells that the pivot can see
     std::unordered_set<Cell> wing_candidates;
-    select_wing_candidates(pivot, mBoard.row(pivot), wing_candidates);
-    select_wing_candidates(pivot, mBoard.column(pivot), wing_candidates);
-    select_wing_candidates(pivot, mBoard.nonet(pivot), wing_candidates);
+    select_wing_candidates(pivot, board.row(pivot), wing_candidates);
+    select_wing_candidates(pivot, board.column(pivot), wing_candidates);
+    select_wing_candidates(pivot, board.nonet(pivot), wing_candidates);
 
     // Try all pairs of visible cells as potential wings
     for (auto it1 = wing_candidates.begin(); it1 != wing_candidates.end(); ++it1) {
@@ -132,17 +162,24 @@ bool Analyzer::find_ywing(const Cell &pivot) {
             const Cell &wing2 = *it2;
 
             std::optional<Value> ywing_value;
-            if (!test_ywing(pivot, wing1, wing2, ywing_value)) continue;
+            if (!test_ywing(board, pivot, wing1, wing2, ywing_value)) continue;
             assert(ywing_value.has_value());
             assert(wing1.check(*ywing_value));
             assert(wing2.check(*ywing_value));
 
-            // Record the Y-Wing pattern
-            YWing yw{*ywing_value, pivot.coord(), {wing1.coord(), wing2.coord()}};
-            if (std::find(mYWings.begin(), mYWings.end(), yw) != mYWings.end()) continue;
+            // Record the Y-Wing pattern -- but is it already recorded? The member
+            // vector dedup (std::find over mYWings) is now a scan of `out` (this
+            // technique's own bucket, so every entry downcasts to YWingFinding).
+            YWingFinding yw{*ywing_value, pivot.coord(), {wing1.coord(), wing2.coord()}};
+            bool already = false;
+            for (auto const &f : out) {
+                assert(dynamic_cast<const YWingFinding *>(f.get()));
+                if (static_cast<const YWingFinding *>(f.get())->same(yw)) { already = true; break; }
+            }
+            if (already) continue;
 
-            mYWings.push_back(yw);
-            if (sVerbose) std::cout << "  [fYW] " << yw << std::endl;
+            if (sVerbose) { std::cout << "  [fYW] "; yw.print(std::cout); std::cout << std::endl; }
+            out.push_back(std::make_shared<YWingFinding>(yw));
             did_find = true;
         }
     }
@@ -150,71 +187,48 @@ bool Analyzer::find_ywing(const Cell &pivot) {
     return did_find;
 }
 
-bool Analyzer::find_ywings() {
-    // https://www.sudokuwiki.org/Y_Wing_Strategy
-    // A Y-Wing consists of three cells, each with exactly two candidates:
-    // - One pivot cell with candidates AB
-    // - One wing cell sharing A with pivot (has candidates AC)
-    // - One wing cell sharing B with pivot (has candidates BC)
-    // The pivot can see both wings, but wings don't need to see each other
-    // Any cell that can see both wings can have candidate C eliminated
-
-    assert(mYWings.empty());
+// https://www.sudokuwiki.org/Y_Wing_Strategy
+// A Y-Wing consists of three cells, each with exactly two candidates:
+// - One pivot cell with candidates AB
+// - One wing cell sharing A with pivot (has candidates AC)
+// - One wing cell sharing B with pivot (has candidates BC)
+// The pivot can see both wings, but wings don't need to see each other
+// Any cell that can see both wings can have candidate C eliminated
+bool YWingTechnique::find(const Board &board, FindingList &out) const {
+    assert(out.empty());
     bool did_find = false;
 
-    for (auto const &cell : mBoard.cells()) {
+    for (auto const &cell : board.cells()) {
         // Is this a note cell with exactly 2 candidates?
         if (!cell.isNote()) continue;
         if (cell.notes().count() != 2) continue;
 
         // Try this cell as a pivot
-        did_find |= find_ywing(cell);
+        did_find |= find_ywing(board, cell, out);
     }
 
     return did_find;
 }
 
-template <class Set>
-bool Analyzer::act_on_ywing(const YWing &entry, const Set &wing1_set) {
-    assert(wing1_set.contains(mBoard.at(entry.wings.first)));
+bool YWingTechnique::apply(Board &board, FindingList &mine) const {
+    if (mine.empty()) return false;
 
     bool did_act = false;
+    for (auto const &f : mine) {
+        // Bucket invariant: every entry in this technique's bucket is a YWingFinding
+        // (see NakedSingleTechnique::apply). The assert turns a wrong-bucket wiring
+        // bug into a caught error, not UB.
+        assert(dynamic_cast<const YWingFinding *>(f.get()));
+        auto const *yw = static_cast<const YWingFinding *>(f.get());
 
-    for (auto const &cell : wing1_set) {
-        if (cell.isValue()) continue;
-        if (cell.coord() == entry.pivot) continue;
-        if (cell.coord() == entry.wings.first) continue;
-        if (cell.coord() == entry.wings.second) continue;
-        if (!cell.check(entry.value)) continue;
-
-        if (mBoard.see_each_other(cell.coord(), entry.wings.second)) {
-            std::cout << "[YW] " << cell.coord() << " x" << entry.value << std::endl;
-            mBoard.clear_note_at(cell.coord(), entry.value);
-            did_act = true;
-        }
+        // for each entry, look for candidates for elimination within the first
+        // wing's row, column or nonet
+        did_act |= act_on_ywing(board, *yw, board.row(yw->wings.first));
+        did_act |= act_on_ywing(board, *yw, board.column(yw->wings.first));
+        did_act |= act_on_ywing(board, *yw, board.nonet(yw->wings.first));
     }
-
-    return did_act;
-}
-
-bool Analyzer::act_on_ywing() {
-    bool did_act = false;
-
-    if (mYWings.empty()) return did_act;
-
-    for (auto const &entry : mYWings) {
-        // for each entry, look for candidates for elimination within the first wing's row, column or nonet
-        did_act |= act_on_ywing(entry, mBoard.row(entry.wings.first));
-        did_act |= act_on_ywing(entry, mBoard.column(entry.wings.first));
-        did_act |= act_on_ywing(entry, mBoard.nonet(entry.wings.first));
-    }
-    mYWings.clear();
+    mine.clear();
 
     assert(did_act);
     return did_act;
-}
-
-std::ostream& operator<<(std::ostream& outs, const Analyzer::YWing &yw) {
-    outs << yw.pivot << "Y{" << yw.wings.first << "," << yw.wings.second << "}#" << yw.value;
-    return outs;
 }

--- a/analyzer-ywing.cpp
+++ b/analyzer-ywing.cpp
@@ -10,6 +10,7 @@
 #include "coord.h"
 #include "verbose.h"
 
+#include <algorithm>
 #include <iterator>
 #include <cassert>
 #include <memory>
@@ -81,6 +82,13 @@ namespace { // anon
     // carry coords) rather than resolved through the friends-only Board::at.
     template <class Set>
     bool act_on_ywing(Board &board, const YWingFinding &entry, const Set &wing1_set) {
+        // Contract mirror of would_act_for_set's find-side assert: the set we were
+        // handed is wing1's own unit. wings.first is a Coord (findings carry coords,
+        // and the ported technique has no friend Board::at to resolve it to a Cell),
+        // so check membership by coord.
+        assert(std::any_of(wing1_set.begin(), wing1_set.end(),
+            [&](const Cell &c) { return c.coord() == entry.wings.first; }));
+
         bool did_act = false;
 
         for (auto const &cell : wing1_set) {

--- a/analyzer-ywing.h
+++ b/analyzer-ywing.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2025, Bertrand Mollinier Toublet
+// See LICENSE for details of BSD 3-Clause License
+#pragma once
+
+#include "technique.h"
+#include "coord.h"
+#include "cell.h"  // Value, Cell used in the finding and the test_ contract below
+
+#include <optional>
+#include <utility>
+
+// Y-Wing: a bivalue pivot cell (candidates AB) that sees two bivalue wings, one
+// carrying AC and one carrying BC. Any cell that sees both wings can then have
+// candidate C eliminated. (https://www.sudokuwiki.org/Y_Wing_Strategy)
+//
+// YW is *given-tuple* shaped (see docs/test-predicate-idiom.md): the pattern's
+// identity is the triple (pivot, wing1, wing2), which find enumerates and a pure
+// test_ywing predicate judges -- so, like naked/hidden pair, that predicate
+// promotes to a public static. It is the lone *non-templated* test_ predicate,
+// so no explicit-instantiation tax applies (contrast test_naked_pair<Row>).
+//
+// Unlike the file-local NakedPairFinding, YWingFinding lives in this header: the
+// whitebox suite drives find_ywing on a crafted pivot and inspects the recorded
+// finding's value (like the scan-fused XWingFinding), so the type must be visible
+// to tests/unit/test_analyzer.cpp. The finding is exposed exactly when the test
+// must read its fields, not merely because the technique is hooked.
+struct YWingFinding : Finding {
+    Value value;                    // candidate eliminated from cells seeing both wings
+    Coord pivot;                    // bivalue pivot (AB)
+    std::pair<Coord, Coord> wings;  // the two bivalue wings (AC, BC)
+
+    YWingFinding(Value v, Coord p, std::pair<Coord, Coord> w)
+        : value(v), pivot(p), wings(w) { }
+
+    // find_ywing accumulates across pivots and dedups (unlike the short-circuiting
+    // fish): two findings are the same Y-Wing iff value, pivot, and both wings
+    // match -- byte-for-byte the old Analyzer::YWing's defaulted operator==.
+    bool same(const YWingFinding &o) const {
+        return value == o.value && pivot == o.pivot && wings == o.wings;
+    }
+    // Byte-for-byte the old free operator<<(ostream, Analyzer::YWing):
+    // "pivotY{wing1,wing2}#value".
+    void print(std::ostream &o) const override {
+        o << pivot << "Y{" << wings.first << "," << wings.second << "}#" << value;
+    }
+};
+
+class YWingTechnique : public Technique {
+public:
+    const char *name() const override { return "YW"; }
+    Tier        tier() const override { return Tier::Advanced; }
+    bool  brace_each() const override { return true; }
+
+    bool find(const Board &, FindingList &out) const override;
+    bool apply(Board &, FindingList &mine) const override;
+
+    // Tested contracts, NOT leaked privates. test_ywing: is (pivot, wing1, wing2)
+    // a genuine, actionable Y-Wing (and if so, what value does it eliminate)?
+    // find_ywing: record every Y-Wing anchored on `pivot` into `out`, deduping
+    // against what is already there. The old Analyzer members were reached by a
+    // friend hook because techniques weren't standalone; now that YWingTechnique
+    // is standalone both promote to public statics (issue #7's stated payoff) so
+    // the whitebox suite drives them directly -- test_ywing on crafted near-misses
+    // and find_ywing on a crafted pivot (then inspecting the recorded
+    // YWingFinding) -- without friendship. Static, not const-member: the technique
+    // is stateless and both read only their arguments (the board is passed in),
+    // matching the promoted-static shape of the other hooked techniques.
+    static bool test_ywing(const Board &, const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value);
+    static bool find_ywing(const Board &, const Cell &pivot, FindingList &out);
+};

--- a/analyzer.cpp
+++ b/analyzer.cpp
@@ -39,6 +39,7 @@ const std::vector<std::unique_ptr<Technique>> &Analyzer::registry() {
         r.push_back(std::make_unique<HiddenPairTechnique>());
         r.push_back(std::make_unique<XWingTechnique>());
         r.push_back(std::make_unique<ColorChainTechnique>());
+        r.push_back(std::make_unique<YWingTechnique>());
         assert(r.size() <= std::size(kCascade));
         for (size_t i = 0; i < r.size(); ++i)
             assert(std::string_view(r[i]->name()) == kCascade[i]);
@@ -91,7 +92,6 @@ void Analyzer::analyze() {
 
     for (auto &b : mFindings) b.clear();
     mSwordfish.clear();
-    mYWings.clear();
     mXYChains.clear();
 
     bool did_find = false;
@@ -106,7 +106,6 @@ void Analyzer::analyze() {
     assert(mFindings.size() == reg.size());
     for (size_t i = 0; i < reg.size() && !did_find; ++i)
         did_find = reg[i]->find(mBoard, mFindings[i]);
-    if (!did_find) did_find = find_ywings();
     if (!did_find) did_find = find_swordfish();
     if (!did_find) did_find = find_xychains();
 }
@@ -124,7 +123,6 @@ bool Analyzer::act(const bool singles_only) {
     }
 
     if (!singles_only) {
-        if (!did_act) did_act = act_on_ywing();
         if (!did_act) did_act = act_on_swordfish();
         if (!did_act) did_act = act_on_xychain();
     }
@@ -178,7 +176,6 @@ std::ostream &operator<<(std::ostream &outs, Analyzer const &a) {
     for (size_t i = 0; i < reg.size(); ++i) {
         print_section(outs, *reg[i], a.mFindings[i]); outs << std::endl;
     }
-    print_section(outs, "YW", a.mYWings,           true);  outs << std::endl;
     print_section(outs, "SF", a.mSwordfish,        true);  outs << std::endl;
     print_section(outs, "XY", a.mXYChains,         true);
 

--- a/analyzer.h
+++ b/analyzer.h
@@ -17,7 +17,6 @@ public:
     Analyzer(Board &board, Analyzer const &other)
         : mFindings(other.mFindings)
         , mSwordfish(other.mSwordfish)
-        , mYWings(other.mYWings)
         , mXYChains(other.mXYChains)
         , mBoard(board) { }
 
@@ -91,28 +90,6 @@ private:
     template<class EliminationSet>
     bool act_on_swordfish(const Swordfish &entry);
     bool act_on_swordfish();
-
-private:
-    //** y-wing
-    struct YWing {
-        Value value;                   // candidate to eliminate from cells seeing both wings
-        Coord pivot;                   // pivot cell with 2 candidates (AB)
-        std::pair<Coord, Coord> wings; // wing cell sharing candidate A with pivot
-
-        bool operator==(const YWing &other) const = default;
-    };
-    friend std::ostream& operator<<(std::ostream& outs, const YWing &);
-    std::vector<YWing> mYWings;
-
-    // find
-    bool test_ywing(const Cell &pivot, const Cell &wing1, const Cell &wing2, std::optional<Value> &out_value) const;
-    bool find_ywing(const Cell &pivot);
-    bool find_ywings();
-
-    // act
-    template<class Set>
-    bool act_on_ywing(const YWing &entry, const Set &set);
-    bool act_on_ywing();
 
 private:
     //** xy-chain

--- a/techniques.h
+++ b/techniques.h
@@ -13,3 +13,4 @@
 #include "analyzer-hiddenpairs.h"
 #include "analyzer-xwing.h"
 #include "analyzer-colorchain.h"
+#include "analyzer-ywing.h"

--- a/tests/unit/test_analyzer.cpp
+++ b/tests/unit/test_analyzer.cpp
@@ -21,6 +21,7 @@
 #include "analyzer-hiddenpairs.h"
 #include "analyzer-xwing.h"
 #include "analyzer-colorchain.h"
+#include "analyzer-ywing.h"
 #include "cell.h"
 #include "coord.h"
 
@@ -95,11 +96,13 @@ struct AnalyzerTest {
     }
 
     // --- y-wing ---
-    static bool   find_ywing(Analyzer &a, const Cell &pivot)                                       { return a.find_ywing(pivot); }
-    static bool   test_ywing(const Analyzer &a, const Cell &p, const Cell &w1, const Cell &w2, std::optional<Value> &out) { return a.test_ywing(p, w1, w2, out); }
-    static bool   act_on_ywing(Analyzer &a)                                                        { return a.act_on_ywing(); }
-    static size_t ywing_count(const Analyzer &a)                                                   { return a.mYWings.size(); }
-    static Value  ywing_value(const Analyzer &a)                                                   { return a.mYWings.at(0).value; }
+    // No hooks: YW is ported to a standalone Technique (issue #7). It is
+    // given-tuple shaped (see docs/test-predicate-idiom.md), so its validation
+    // predicate promotes to a public static YWingTechnique::test_ywing the cases
+    // call directly on crafted near-misses. Because those cases also drive
+    // find_ywing on a crafted pivot and read the recorded finding's value,
+    // find_ywing is likewise a public static and YWingFinding is declared in
+    // analyzer-ywing.h -- both without friendship.
 
     // --- x-wing / naked pair / hidden pair ---
     // No hooks: all three are ported to standalone Techniques (issue #7). Naked
@@ -337,15 +340,19 @@ void test_ywing_detect_and_act() {
     set_candidates(board, 1, 1, {3, 4});   // sees both wings; the target
     confine_value(board, kThree, { {0,1}, {1,0}, {1,1} });
 
-    Analyzer analyzer(board);
-    bool found = AnalyzerTest::find_ywing(analyzer, cell_at(board, 0, 0));
+    FindingList findings;
+    bool found = YWingTechnique::find_ywing(board, cell_at(board, 0, 0), findings);
     check(found, "Y-wing detected with pivot (0,0)");
-    check(AnalyzerTest::ywing_count(analyzer) == 1, "exactly one Y-wing recorded");
-    if (AnalyzerTest::ywing_count(analyzer) == 1)
-        check(AnalyzerTest::ywing_value(analyzer) == kThree, "elimination value is 3");
+    check(findings.size() == 1, "exactly one Y-wing recorded");
+    if (findings.size() == 1) {
+        assert(dynamic_cast<const YWingFinding *>(findings.front().get()));
+        auto const *yw = static_cast<const YWingFinding *>(findings.front().get());
+        check(yw->value == kThree, "elimination value is 3");
+    }
 
-    bool acted = AnalyzerTest::act_on_ywing(analyzer);
-    check(acted, "act_on_ywing reports an elimination");
+    YWingTechnique tech;
+    bool acted = tech.apply(board, findings);
+    check(acted, "apply reports an elimination");
     check(!has_candidate(board, 1, 1, kThree), "candidate 3 eliminated from (1,1)");
     check(has_candidate(board, 0, 1, kThree) && has_candidate(board, 1, 0, kThree),
           "wing cells kept candidate 3");
@@ -361,13 +368,12 @@ void test_ywing_rejects_non_patterns() {
     set_candidates(board, 1, 0, {1, 4});   // shares 1 too (same as the other wing)
     set_candidates(board, 2, 0, {2, 5});   // shares 2, other 5 (!= 3)
 
-    Analyzer analyzer(board);
     std::optional<Value> out;  // out-param; only engaged when test_ywing returns true
-    bool both_share_one = AnalyzerTest::test_ywing(analyzer,
+    bool both_share_one = YWingTechnique::test_ywing(board,
         cell_at(board, 0, 0), cell_at(board, 0, 1), cell_at(board, 1, 0), out);
     check(!both_share_one, "rejected: both wings share the same value with the pivot");
 
-    bool others_differ = AnalyzerTest::test_ywing(analyzer,
+    bool others_differ = YWingTechnique::test_ywing(board,
         cell_at(board, 0, 0), cell_at(board, 0, 1), cell_at(board, 2, 0), out);
     check(!others_differ, "rejected: the wings' non-shared values differ");
 }
@@ -745,8 +751,8 @@ void test_rebinding_ctor_carries_findings() {
 
     Analyzer a(board);
     a.analyze();
-    check(AnalyzerTest::findings_bucket_count(a) == 7, "seven registry buckets (NS, HS, NP, LC, HP, XW, SC)");
-    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC/HP/XW/SC short-circuited)");
+    check(AnalyzerTest::findings_bucket_count(a) == 8, "eight registry buckets (NS, HS, NP, LC, HP, XW, SC, YW)");
+    check(AnalyzerTest::findings_total(a) == 1, "the naked single was recorded in a's bucket (HS/NP/LC/HP/XW/SC/YW short-circuited)");
 
     // Copy the candidate grid and rebind onto it -- this is the ONLY operation
     // under test. b.analyze() is deliberately never called.


### PR DESCRIPTION
Ports **Y-Wing (YW)** to the stateless `Technique` registry — the next entry in the `registry()` cascade after Simple Coloring. Cascade order is `NS, HS, NP, LC, HP, XW, SC, YW, SF, XY`, and the registry must stay a strict in-order **prefix** of it (asserted in `registry()`), so YW ports before SF even though the fish are algorithmic twins.

## What changed
- **`analyzer-ywing.h`** (new): `YWingFinding : Finding` (value/pivot/wings, `same()` for dedup, `print()`) and `YWingTechnique`. YW is *given-tuple* shaped, so `test_ywing` promotes to a public static — and being the lone non-templated `test_` predicate, it needs no explicit-instantiation tax. `find_ywing` is also a public static and the finding lives in the header because the whitebox suite reads its fields (the scan-fused/finding-in-header seam shape, driven here by a given-tuple predicate).
- **`analyzer-ywing.cpp`**: rewritten off `Analyzer` — helpers in an anon namespace, cells addressed by coord (no friend `Board::at`), the old member-vector dedup replaced by a scan of the technique's own bucket (mirrors the naked-pair port). YW accumulates across pivots, unlike the short-circuiting fish.
- **`analyzer.h` / `analyzer.cpp` / `techniques.h`**: `YWingTechnique` added to the registry; dropped the `YWing` struct/member/decls, the three suffix sites (`analyze()`, `act()`, `operator<<`), and the `mYWings` rebinding-ctor copy.
- **`tests/unit/test_analyzer.cpp`**: deleted the YW friend hooks, rewrote both YW cases against the public statics + `FindingList` + `apply`, bumped the registry bucket count 7→8.

## Verification
- Clean `-Wall -Werror` build, no warnings.
- `make unit`: all checks pass (both rewritten YW cases + bucket-count).
- `make test`: 80/80, including YW per-technique precision.
- **Byte-identical** full REPL solve transcript vs. the pre-change binary on the `P_yw1` Y-Wing fixture, including multi-finding dumps like `[YW](2) {{[3, 3]Y{[1, 2],[3, 6]}#9}, {[3, 3]Y{[2, 2],[3, 8]}#9}}` — finding format and multi-item ordering preserved (YW's vector-backed findings avoid SC's `unordered_map` reordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)